### PR TITLE
Fix parsing charset strings with semicolon

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -57,7 +57,7 @@ func (ctx *ProxyCtx) Warnf(msg string, argv ...interface{}) {
 	ctx.printf("WARN: "+msg, argv...)
 }
 
-var charsetFinder = regexp.MustCompile("charset=([^ ]*)")
+var charsetFinder = regexp.MustCompile("charset=([^ ;]*)")
 
 // Will try to infer the character set of the request from the headers.
 // Returns the empty string if we don't know which character set it used.


### PR DESCRIPTION
Avoid problem with charset defined as utf-8;
saw a couple of WARN messages saying "Cannot convert from UTF-8; to utf-8:..."
