### PR TITLE
fix dial proxy issue.

### DIFF
--- a/https.go
+++ b/https.go
@@ -91,7 +91,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 			if !hasPort.MatchString(u.Host) {
 				panic("https proxy should has port, like 8080")
 			}
-			targetSiteCon, e = proxy.dial("tcp", https_proxy)
+			targetSiteCon, e = proxy.dial("tcp", u.Host)
 		} else {
 			targetSiteCon, e = proxy.dial("tcp", host)
 		}


### PR DESCRIPTION
fix dial proxy issue. without the change, goproxy will dial url like http://myproxy.com:8080
but it should dial myproxy.com:8080 instead.
