### PR TITLE
Fixing #26 while still defeating the infinite recursion bug in #53

### DIFF
--- a/examples/transparent/proxy.sh
+++ b/examples/transparent/proxy.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# goproxy IP
+GOPROXY_SERVER="10.10.10.1"
+# goproxy port
+GOPROXY_PORT="3129"
+# DO NOT MODIFY BELOW
+# Load IPTABLES modules for NAT and IP conntrack support
+modprobe ip_conntrack
+modprobe ip_conntrack_ftp
+echo 1 > /proc/sys/net/ipv4/ip_forward
+echo 2 > /proc/sys/net/ipv4/conf/all/rp_filter
+
+# Clean old firewall
+iptables -t nat -F
+iptables -t nat -X
+iptables -t mangle -F
+iptables -t mangle -X
+
+# Write new rules
+iptables -t nat -A PREROUTING -s $GOPROXY_SERVER -p tcp --dport $GOPROXY_PORT -j ACCEPT
+iptables -t nat -A PREROUTING -p tcp --dport 80 -j DNAT --to-destination $GOPROXY_SERVER:$GOPROXY_PORT
+iptables -t nat -A POSTROUTING -j MASQUERADE
+iptables -t mangle -A PREROUTING -p tcp --dport $GOPROXY_PORT -j DROP

--- a/examples/transparent/transparent.go
+++ b/examples/transparent/transparent.go
@@ -10,6 +10,7 @@ import (
 
 func main() {
 	proxy := goproxy.NewProxyHttpServer()
+	proxy.Verbose = true
 	proxy.NonproxyHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Host == "" {
 			fmt.Fprintln(w, "Cannot handle requests without Host header, e.g., HTTP 1.0")


### PR DESCRIPTION
If you're running goproxy in Transparent mode, this does require you to set Transparent to true

This does add some minor overhead in looking up the destination host, but that would have to be done anyhow later in the process and this will almost certainly cache the result but does depend on your specific configuration
