### PR TITLE
Adding in RemoteAddr field to requests converted from CONNECT

### DIFF
--- a/https.go
+++ b/https.go
@@ -173,6 +173,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 					ctx.Warnf("Cannot read TLS request from mitm'd client %v %v", r.Host, err)
 					return
 				}
+				req.RemoteAddr = r.RemoteAddr // since we're converting the request, need to carry over the original connecting IP as well
 				ctx.Logf("req %v", r.Host)
 				req.URL, err = url.Parse("https://" + r.Host + req.URL.String())
 				req, resp := proxy.filterRequest(req, ctx)


### PR DESCRIPTION
If you want to filter proxy requests by who connected, the RemoteAddr field of the *http.Request needs to be populated on the *http.Request object when converting from a CONNECT request