### PR TITLE
More examples documentation

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -43,7 +43,7 @@ func (c RespConditionFunc) HandleResp(resp *http.Response, ctx *ProxyCtx) bool {
 	return c(resp, ctx)
 }
 
-// UrlHasPrefix returns a ReqCondtion checking wether the destination URL the proxy client has requested
+// UrlHasPrefix returns a ReqCondition checking wether the destination URL the proxy client has requested
 // has the given prefix, with or without the host.
 // For example UrlHasPrefix("host/x") will match requests of the form 'GET host/x', and will match
 // requests to url 'http://host/x'
@@ -117,21 +117,21 @@ func UrlMatches(re *regexp.Regexp) ReqConditionFunc {
 	}
 }
 
-// DstHostIs returns a ReqCondtion testing wether the host in the request url is the given string
+// DstHostIs returns a ReqCondition testing wether the host in the request url is the given string
 func DstHostIs(host string) ReqConditionFunc {
 	return func(req *http.Request, ctx *ProxyCtx) bool {
 		return req.URL.Host == host
 	}
 }
 
-// SrcIpIs returns a ReqCondtion testing wether the source IP of the request is the given string
+// SrcIpIs returns a ReqCondition testing wether the source IP of the request is the given string
 func SrcIpIs(ip string) ReqCondition {
 	return ReqConditionFunc(func(req *http.Request, ctx *ProxyCtx) bool {
 		return strings.HasPrefix(req.RemoteAddr, ip+":")
 	})
 }
 
-// Not returns a ReqCondtion negating the given ReqCondition
+// Not returns a ReqCondition negating the given ReqCondition
 func Not(r ReqCondition) ReqConditionFunc {
 	return func(req *http.Request, ctx *ProxyCtx) bool {
 		return !r.HandleReq(req, ctx)

--- a/examples/goproxy-basic/README.md
+++ b/examples/goproxy-basic/README.md
@@ -1,0 +1,29 @@
+# Simple HTTP Proxy
+
+`goproxy-basic` starts an HTTP proxy on :8080. It only handles explicit CONNECT
+requests.
+
+Start it in one shell:
+
+```sh
+goproxy-basic -v
+```
+
+Fetch goproxy homepage in another:
+
+```sh
+http_proxy=http://127.0.0.1:8080 wget -O - \
+	http://ripper234.com/p/introducing-goproxy-light-http-proxy/
+```
+
+The homepage HTML content should be displayed in the console. The proxy should
+have logged the request being processed:
+
+```sh
+2015/04/09 18:19:17 [001] INFO: Got request /p/introducing-goproxy-light-http-proxy/ ripper234.com GET http://ripper234.com/p/introducing-goproxy-light-http-proxy/
+2015/04/09 18:19:17 [001] INFO: Sending request GET http://ripper234.com/p/introducing-goproxy-light-http-proxy/
+2015/04/09 18:19:18 [001] INFO: Received response 200 OK
+2015/04/09 18:19:18 [001] INFO: Copying response to client 200 OK [200]
+2015/04/09 18:19:18 [001] INFO: Copied 44333 bytes to client error=<nil>
+```
+

--- a/examples/goproxy-httpdump/README.md
+++ b/examples/goproxy-httpdump/README.md
@@ -1,0 +1,30 @@
+# Trace HTTP Requests and Responses
+
+`goproxy-httpdump` starts an HTTP proxy on :8080. It handles explicit CONNECT
+requests and traces them in a "db" directory created in the proxy working
+directory.  Each request type and headers are logged in a "log" file, while
+their bodies are dumped in files prefixed with the request session identifier.
+
+Additionally, the example demonstrates how to:
+- Log information asynchronously (see HttpLogger)
+- Allow the proxy to be stopped manually while ensuring all pending requests
+  have been processed (in this case, logged).
+
+Start it in one shell:
+
+```sh
+goproxy-httpdump
+```
+
+Fetch goproxy homepage in another:
+
+```sh
+http_proxy=http://127.0.0.1:8080 wget -O - \
+	http://ripper234.com/p/introducing-goproxy-light-http-proxy/
+```
+
+A "db" directory should have appeared where you started the proxy, containing
+two files:
+- log: the request/response traces
+- 1\_resp: the first response body
+

--- a/examples/goproxy-jquery-version/README.md
+++ b/examples/goproxy-jquery-version/README.md
@@ -1,0 +1,31 @@
+# Content Analysis
+
+`goproxy-jquery-version` starts an HTTP proxy on :8080. It checks HTML
+responses, looks for scripts referencing jQuery library and emits warnings if
+different versions of the library are being used for a given host.
+
+Start it in one shell:
+
+```sh
+goproxy-jquery-version
+```
+
+Fetch goproxy homepage in another:
+
+```sh
+http_proxy=http://127.0.0.1:8080 wget -O - \
+	http://ripper234.com/p/introducing-goproxy-light-http-proxy/
+```
+
+Goproxy homepage uses jQuery and a mix of plugins. First the proxy reports the
+first use of jQuery it detects for the domain. Then, because the regular
+expression matching the jQuery sources is imprecise, it reports a mismatch with
+a plugin reference:
+
+```sh
+2015/04/11 11:23:02 [001] WARN: ripper234.com uses //ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js
+2015/04/11 11:23:02 [001] WARN: In http://ripper234.com/p/introducing-goproxy-light-http-proxy/, \
+  Contradicting jqueries //ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js \
+  http://ripper234.wpengine.netdna-cdn.com/wp-content/plugins/wp-ajax-edit-comments/js/jquery.colorbox.min.js?ver=5.0.36
+```
+

--- a/examples/goproxy-jquery-version/jquery_test.go
+++ b/examples/goproxy-jquery-version/jquery_test.go
@@ -61,8 +61,6 @@ func TestDefectiveScriptParser(t *testing.T) {
 	}
 }
 
-func get(url string, t *testing.T) {
-}
 func proxyWithLog() (*http.Client, *bytes.Buffer) {
 	proxy := NewJqueryVersionProxy()
 	proxyServer := httptest.NewServer(proxy)
@@ -73,56 +71,48 @@ func proxyWithLog() (*http.Client, *bytes.Buffer) {
 	client := &http.Client{Transport: tr}
 	return client, buf
 }
+
+func get(t *testing.T, server *httptest.Server, client *http.Client, url string) {
+	resp, err := client.Get(server.URL + url)
+	if err != nil {
+		t.Fatal("cannot get proxy", err)
+	}
+	ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+}
+
 func TestProxyServiceTwoVersions(t *testing.T) {
 	var fs = httptest.NewServer(http.FileServer(http.Dir(".")))
 	defer fs.Close()
 
 	client, buf := proxyWithLog()
 
-	get := func(url string) {
-		resp, err := client.Get(fs.URL + url)
-		if err != nil {
-			t.Fatal("Cannot get proxy", err)
-		}
-		ioutil.ReadAll(resp.Body)
-		resp.Body.Close()
-	}
-
-	get("/w3schools.html")
-	get("/php_man.html")
+	get(t, fs, client, "/w3schools.html")
+	get(t, fs, client, "/php_man.html")
 	if buf.String() != "" &&
 		!strings.Contains(buf.String(), " uses jquery ") {
 		t.Error("shouldn't warn on a single URL", buf.String())
 	}
-	get("/jquery1.html")
+	get(t, fs, client, "/jquery1.html")
 	warnings := buf.String()
 	if !strings.Contains(warnings, "http://ajax.googleapis.com/ajax/libs/jquery/1.3.2/jquery.min.js") ||
 		!strings.Contains(warnings, "jquery.1.4.js") ||
 		!strings.Contains(warnings, "Contradicting") {
-		t.Error("contadicting jquery versions (php_man.html, w3schools.html) does not issue warning", warnings)
+		t.Error("contradicting jquery versions (php_man.html, w3schools.html) does not issue warning", warnings)
 	}
 }
+
 func TestProxyService(t *testing.T) {
 	var fs = httptest.NewServer(http.FileServer(http.Dir(".")))
 	defer fs.Close()
 
 	client, buf := proxyWithLog()
 
-	get := func(url string) {
-		resp, err := client.Get(fs.URL + url)
-		if err != nil {
-			t.Fatal("Cannot get proxy", err)
-		}
-		ioutil.ReadAll(resp.Body)
-		resp.Body.Close()
-	}
-	get("/jquery_homepage.html")
-
+	get(t, fs, client, "/jquery_homepage.html")
 	warnings := buf.String()
 	if !strings.Contains(warnings, "http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js") ||
 		!strings.Contains(warnings, "http://code.jquery.com/jquery-1.4.2.min.js") ||
 		!strings.Contains(warnings, "Contradicting") {
-		t.Error("contadicting jquery versions does not issue warning")
+		t.Error("contradicting jquery versions does not issue warning")
 	}
-
 }

--- a/examples/goproxy-jquery-version/jquery_test.go
+++ b/examples/goproxy-jquery-version/jquery_test.go
@@ -90,7 +90,8 @@ func TestProxyServiceTwoVersions(t *testing.T) {
 
 	get("/w3schools.html")
 	get("/php_man.html")
-	if buf.String() != "" {
+	if buf.String() != "" &&
+		!strings.Contains(buf.String(), " uses jquery ") {
 		t.Error("shouldn't warn on a single URL", buf.String())
 	}
 	get("/jquery1.html")

--- a/examples/goproxy-jquery-version/main.go
+++ b/examples/goproxy-jquery-version/main.go
@@ -8,15 +8,17 @@ import (
 	"regexp"
 )
 
-func findScriptSrc(html string) []string {
+var (
 	// who said we can't parse HTML with regexp?
-	scriptMatcher := regexp.MustCompile(`(?i:<script\s+)`)
-	srcAttrMatcher := regexp.MustCompile(`^(?i:[^>]*\ssrc=["']([^"']*)["'])`)
+	scriptMatcher  = regexp.MustCompile(`(?i:<script\s+)`)
+	srcAttrMatcher = regexp.MustCompile(`^(?i:[^>]*\ssrc=["']([^"']*)["'])`)
+)
 
+// findScripts returns all sources of HTML script tags found in input text.
+func findScriptSrc(html string) []string {
 	srcs := make([]string, 0)
 	matches := scriptMatcher.FindAllStringIndex(html, -1)
 	for _, match := range matches {
-		//println("Match",html[match[0]:match[1]])
 		// -1 to capture the whitespace at the end of the script tag
 		srcMatch := srcAttrMatcher.FindStringSubmatch(html[match[1]-1:])
 		if srcMatch != nil {
@@ -26,20 +28,28 @@ func findScriptSrc(html string) []string {
 	return srcs
 }
 
+// NewJQueryVersionProxy creates a proxy checking responses HTML content, looks
+// for scripts referencing jQuery library and emits warnings if different
+// versions of the library are being used for a given host.
 func NewJqueryVersionProxy() *goproxy.ProxyHttpServer {
 	proxy := goproxy.NewProxyHttpServer()
 	m := make(map[string]string)
 	jqueryMatcher := regexp.MustCompile(`(?i:jquery\.)`)
 	proxy.OnResponse(goproxy_html.IsHtml).Do(goproxy_html.HandleString(
 		func(s string, ctx *goproxy.ProxyCtx) string {
-			//ctx.Warnf("Charset %v by %v",ctx.Charset(),ctx.Req.Header["Content-Type"])
 			for _, src := range findScriptSrc(s) {
-				if jqueryMatcher.MatchString(src) {
-					prev, ok := m[ctx.Req.Host]
-					if ok && prev != src {
-						ctx.Warnf("In %v, Contradicting jqueries %v %v", ctx.Req.URL, prev, src)
+				if !jqueryMatcher.MatchString(src) {
+					continue
+				}
+				prev, ok := m[ctx.Req.Host]
+				if ok {
+					if prev != src {
+						ctx.Warnf("In %v, Contradicting jqueries %v %v",
+							ctx.Req.URL, prev, src)
 						break
 					}
+				} else {
+					ctx.Warnf("%s uses jquery %s", ctx.Req.Host, src)
 					m[ctx.Req.Host] = src
 				}
 			}
@@ -50,6 +60,5 @@ func NewJqueryVersionProxy() *goproxy.ProxyHttpServer {
 
 func main() {
 	proxy := NewJqueryVersionProxy()
-	//proxy.Verbose = true
 	log.Fatal(http.ListenAndServe(":8080", proxy))
 }

--- a/examples/goproxy-no-reddit-at-worktime/README.md
+++ b/examples/goproxy-no-reddit-at-worktime/README.md
@@ -1,0 +1,21 @@
+# Request Filtering
+
+`goproxy-no-reddit-at-work` starts an HTTP proxy on :8080. It denies requests
+to "www.reddit.com" made between 8am to 5pm inclusive, local time.
+
+Start it in one shell:
+
+```sh
+$ goproxy-no-reddit-at-work
+```
+
+Fetch reddit in another:
+
+```sh
+$ http_proxy=http://127.0.0.1:8080 wget -O - http://www.reddit.com
+--2015-04-11 16:59:01--  http://www.reddit.com/
+Connecting to 127.0.0.1:8080... connected.
+Proxy request sent, awaiting response... 403 Forbidden
+2015-04-11 16:59:01 ERROR 403: Forbidden.
+```
+

--- a/examples/goproxy-no-reddit-at-worktime/noreddit.go
+++ b/examples/goproxy-no-reddit-at-worktime/noreddit.go
@@ -11,10 +11,13 @@ func main() {
 	proxy := goproxy.NewProxyHttpServer()
 	proxy.OnRequest(goproxy.DstHostIs("www.reddit.com")).DoFunc(
 		func(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-			if h, _, _ := time.Now().Clock(); h >= 8 && h <= 17 {
+			h, _, _ := time.Now().Clock()
+			if h >= 8 && h <= 17 {
 				return r, goproxy.NewResponse(r,
 					goproxy.ContentTypeText, http.StatusForbidden,
 					"Don't waste your time!")
+			} else {
+				ctx.Warnf("clock: %d, you can waste your time...", h)
 			}
 			return r, nil
 		})

--- a/ext/html/html.go
+++ b/ext/html/html.go
@@ -31,7 +31,7 @@ var IsWebRelatedText goproxy.RespCondition = goproxy.ContentTypeIs("text/html",
 	"text/xml",
 	"text/json")
 
-// HandleString will recieve a function that filters a string, and will convert the
+// HandleString will receive a function that filters a string, and will convert the
 // request body to a utf8 string, according to the charset specified in the Content-Type
 // header.
 // guessing Html charset encoding from the <META> tags is not yet implemented.
@@ -46,7 +46,7 @@ func HandleString(f func(s string, ctx *goproxy.ProxyCtx) string) goproxy.RespHa
 	})
 }
 
-// Will recieve an input stream which would convert the response to utf-8
+// Will receive an input stream which would convert the response to utf-8
 // The given function must close the reader r, in order to close the response body.
 func HandleStringReader(f func(r io.Reader, ctx *goproxy.ProxyCtx) io.Reader) goproxy.RespHandler {
 	return goproxy.FuncRespHandler(func(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {


### PR DESCRIPTION
Hello,

Here is a little more documentation and cleanup of goproxy examples. It is far from done but this might help newcomers a bit. It certainly improved my understanding of goproxy by reading and tidying up some code. This is a cosmetic pass, some examples seem too complicated like the one logging HTTP content: the logging code, while interesting, seems a bit irrelevant and makes things harder by adding a lot of logic for clean process termination. I may go back to that once I have a clear picture of the remaining samples.

Also, what about gofmt'ing the code?