### PR TITLE
proxy: force HttpRequest.Close to false when dropping hop-by-hop headers

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -89,6 +89,7 @@ func removeProxyHeaders(ctx *ProxyCtx, r *http.Request) {
 	//   options that are desired for that particular connection and MUST NOT
 	//   be communicated by proxies over further connections.
 	r.Header.Del("Connection")
+	r.Close = false
 }
 
 // Standard net/http function. Shouldn't be used directly, http.Serve will use it.


### PR DESCRIPTION
I suppose there is logic in HttpRequest to set the field when receiving
the header, but apparently it does not keep both in sync (or favor the
field). The tests were failing for me on OSX10 / Go 1.4.2 with:

--- FAIL: TestNoProxyHeaders (0.00s)
        proxy_test.go:535: Got Connection header from goproxy map[Connection:[close] Accept-Encoding:[gzip] User-Agent:[Go 1.1 package http]]
--- FAIL: TestNoProxyHeadersHttps (0.27s)
        proxy_test.go:535: Got Connection header from goproxy map[User-Agent:[Go 1.1 package http] Connection:[close] Accept-Encoding:[gzip]]
FAIL
FAIL    github.com/elazarl/goproxy      2.428s

Probably fixed https://github.com/elazarl/goproxy/issues/92, which I noticed while submitting the PR.
