### PR TITLE
httpdump: make TeeReadCloser.Close fail if either output fails

### DIFF
--- a/examples/goproxy-httpdump/httpdump.go
+++ b/examples/goproxy-httpdump/httpdump.go
@@ -199,9 +199,9 @@ func (t *TeeReadCloser) Close() error {
 	err1 := t.c.Close()
 	err2 := t.w.Close()
 	if err1 != nil {
-		return err2
+		return err1
 	}
-	return err1
+	return err2
 }
 
 // stoppableListener serves stoppableConn and tracks their lifetime to notify


### PR DESCRIPTION
This should fix https://github.com/elazarl/goproxy/issues/81

I did not touch it when refactoring the code because the intent was not clear to me. But according to the issue, you want to fail fast, which makes sense, then just let do that.