### PR TITLE
Remove extra slash from UrlHasPrefix

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -50,7 +50,7 @@ func (c RespConditionFunc) HandleResp(resp *http.Response, ctx *ProxyCtx) bool {
 func UrlHasPrefix(prefix string) ReqConditionFunc {
 	return func(req *http.Request, ctx *ProxyCtx) bool {
 		return strings.HasPrefix(req.URL.Path, prefix) ||
-			strings.HasPrefix(req.URL.Host+"/"+req.URL.Path, prefix) ||
+			strings.HasPrefix(req.URL.Host+req.URL.Path, prefix) ||
 			strings.HasPrefix(req.URL.Scheme+req.URL.Host+req.URL.Path, prefix)
 	}
 }

--- a/https.go
+++ b/https.go
@@ -176,11 +176,11 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 				req.RemoteAddr = r.RemoteAddr // since we're converting the request, need to carry over the original connecting IP as well
 				ctx.Logf("req %v", r.Host)
 				req.URL, err = url.Parse("https://" + r.Host + req.URL.String())
-				
-				// Bug fix which goproxy fails to provide request 
-				// information URL in the context when does HTTPS MITM 
+
+				// Bug fix which goproxy fails to provide request
+				// information URL in the context when does HTTPS MITM
 				ctx.Req = req
-				
+
 				req, resp := proxy.filterRequest(req, ctx)
 				if resp == nil {
 					if err != nil {


### PR DESCRIPTION
URL.Path already has a leading slash, so adding our own slash causes strings.HasPrefix to fail.