### PR TITLE
Allow SrcIpIs to accept multiple parameters

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -124,10 +124,15 @@ func DstHostIs(host string) ReqConditionFunc {
 	}
 }
 
-// SrcIpIs returns a ReqCondition testing wether the source IP of the request is the given string
-func SrcIpIs(ip string) ReqCondition {
+// SrcIpIs returns a ReqCondition testing whether the source IP of the request is one of the given strings
+func SrcIpIs(ips ...string) ReqCondition {
 	return ReqConditionFunc(func(req *http.Request, ctx *ProxyCtx) bool {
-		return strings.HasPrefix(req.RemoteAddr, ip+":")
+		for _, ip := range ips {
+			if strings.HasPrefix(req.RemoteAddr, ip+":") {
+				return true
+			}
+		}
+		return false
 	})
 }
 


### PR DESCRIPTION
Made a backwards-compatible change to allow the ReqCondition SrcIpIs to accept a list of IP addresses.