### PR TITLE
Avoid tooo many warns due to clients' closed connections

### DIFF
--- a/https.go
+++ b/https.go
@@ -255,7 +255,7 @@ func httpError(w io.WriteCloser, ctx *ProxyCtx, err error) {
 
 func copyAndClose(ctx *ProxyCtx, w, r net.Conn) {
 	connOk := true
-	if _, err := io.Copy(w, r); err != nil {
+	if bytes, err := io.Copy(w, r); err != nil && bytes <= 0 {
 		connOk = false
 		ctx.Warnf("Error copying to client: %s", err)
 	}


### PR DESCRIPTION
In https, the clients close the connections when they receive the expected data, it's harmless. This patch  avoids warnings if it could write bytes to the clients.
