### PR TITLE
Solves the https write to client error and add bytes counter

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -19,8 +19,10 @@ type ProxyCtx struct {
 	// call of RespHandler
 	UserData interface{}
 	// Will connect a request to a response
-	Session int64
-	proxy   *ProxyHttpServer
+	Session         int64
+	proxy           *ProxyHttpServer
+	bytesUpstream   int64
+	bytesDownstream int64
 }
 
 type RoundTripper interface {

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -23,6 +23,11 @@ type RespCondition interface {
 	HandleResp(resp *http.Response, ctx *ProxyCtx) bool
 }
 
+// It's called when the connection is closed
+type OnClose interface {
+	HandleClose(ctx *ProxyCtx)
+}
+
 // ReqConditionFunc.HandleReq(req,ctx) <=> ReqConditionFunc(req,ctx)
 type ReqConditionFunc func(req *http.Request, ctx *ProxyCtx) bool
 
@@ -289,6 +294,13 @@ func (pcond *ProxyConds) Do(h RespHandler) {
 //	proxy.OnResponse(cond1,cond2).Do(handler) // handler.Handle(resp,ctx) will be used
 //				// if cond1.HandleResp(resp) && cond2.HandleResp(resp)
 func (proxy *ProxyHttpServer) OnResponse(conds ...RespCondition) *ProxyConds {
+	return &ProxyConds{proxy, make([]ReqCondition, 0), conds}
+}
+
+// OnResponse is used when adding a response-filter to the HTTP proxy, usual pattern is
+//	proxy.OnResponse(cond1,cond2).Do(handler) // handler.Handle(resp,ctx) will be used
+//				// if cond1.HandleResp(resp) && cond2.HandleResp(resp)
+func (proxy *ProxyHttpServer) OnClose(conds ...RespCondition) *ProxyConds {
 	return &ProxyConds{proxy, make([]ReqCondition, 0), conds}
 }
 

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -23,11 +23,6 @@ type RespCondition interface {
 	HandleResp(resp *http.Response, ctx *ProxyCtx) bool
 }
 
-// It's called when the connection is closed
-type OnClose interface {
-	HandleClose(ctx *ProxyCtx)
-}
-
 // ReqConditionFunc.HandleReq(req,ctx) <=> ReqConditionFunc(req,ctx)
 type ReqConditionFunc func(req *http.Request, ctx *ProxyCtx) bool
 
@@ -294,13 +289,6 @@ func (pcond *ProxyConds) Do(h RespHandler) {
 //	proxy.OnResponse(cond1,cond2).Do(handler) // handler.Handle(resp,ctx) will be used
 //				// if cond1.HandleResp(resp) && cond2.HandleResp(resp)
 func (proxy *ProxyHttpServer) OnResponse(conds ...RespCondition) *ProxyConds {
-	return &ProxyConds{proxy, make([]ReqCondition, 0), conds}
-}
-
-// OnResponse is used when adding a response-filter to the HTTP proxy, usual pattern is
-//	proxy.OnResponse(cond1,cond2).Do(handler) // handler.Handle(resp,ctx) will be used
-//				// if cond1.HandleResp(resp) && cond2.HandleResp(resp)
-func (proxy *ProxyHttpServer) OnClose(conds ...RespCondition) *ProxyConds {
 	return &ProxyConds{proxy, make([]ReqCondition, 0), conds}
 }
 

--- a/https.go
+++ b/https.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -282,7 +281,6 @@ func pipeAndClose(ctx *ProxyCtx, targetSiteCon, proxyClient net.Conn) {
 			proxyClient.SetReadDeadline(time.Now())
 		}
 	}
-	fmt.Printf("up: %d, down: %d\n", ctx.bytesUpstream, ctx.bytesDownstream)
 }
 
 func copyAndClose(ctx *ProxyCtx, w, r net.Conn) (bytes int64) {
@@ -296,7 +294,6 @@ func copyAndClose(ctx *ProxyCtx, w, r net.Conn) (bytes int64) {
 	if err := r.Close(); err != nil && connOk {
 		ctx.Warnf("Error closing: %s", err)
 	}
-	fmt.Printf("c: %d\n", bytes)
 	return bytes
 }
 

--- a/https.go
+++ b/https.go
@@ -255,7 +255,7 @@ func httpError(w io.WriteCloser, ctx *ProxyCtx, err error) {
 
 func copyAndClose(ctx *ProxyCtx, w, r net.Conn) {
 	connOk := true
-	if _, err := io.Copy(w, r); err != nil {
+	if bytes, err := io.Copy(w, r); err != nil && bytes <= 0 {
 		connOk = false
 		ctx.Warnf("Error copying to client: %s", err)
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -2,7 +2,6 @@ package goproxy
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"log"
 	"net"
@@ -145,7 +144,6 @@ func (proxy *ProxyHttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		}
 		ctx.bytesDownstream += nr
 		ctx.Logf("Copied %v bytes to client error=%v", nr, err)
-		fmt.Printf("up: %d, down: %d\n", ctx.bytesUpstream, ctx.bytesDownstream)
 	}
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -27,7 +27,8 @@ type ProxyHttpServer struct {
 	Tr              *http.Transport
 	// ConnectDial will be used to create TCP connections for CONNECT requests
 	// if nil Tr.Dial will be used
-	ConnectDial func(network string, addr string) (net.Conn, error)
+	ConnectDial func(network string, addr string) (net.Conn, error),
+	closeHandlers: []OnClose{},
 }
 
 var hasPort = regexp.MustCompile(`:\d+$`)
@@ -161,7 +162,7 @@ func NewProxyHttpServer() *ProxyHttpServer {
 		}),
 		Tr: &http.Transport{TLSClientConfig: tlsClientSkipVerify,
 			Proxy: http.ProxyFromEnvironment},
-		endSessionHandler: []EndSessionHandler{},
+		endHandler: []OnEndHandler{},
 	}
 	proxy.ConnectDial = dialerFromEnv(&proxy)
 	return &proxy

--- a/proxy.go
+++ b/proxy.go
@@ -27,8 +27,7 @@ type ProxyHttpServer struct {
 	Tr              *http.Transport
 	// ConnectDial will be used to create TCP connections for CONNECT requests
 	// if nil Tr.Dial will be used
-	ConnectDial func(network string, addr string) (net.Conn, error),
-	closeHandlers: []OnClose{},
+	ConnectDial func(network string, addr string) (net.Conn, error)
 }
 
 var hasPort = regexp.MustCompile(`:\d+$`)
@@ -162,7 +161,6 @@ func NewProxyHttpServer() *ProxyHttpServer {
 		}),
 		Tr: &http.Transport{TLSClientConfig: tlsClientSkipVerify,
 			Proxy: http.ProxyFromEnvironment},
-		endHandler: []OnEndHandler{},
 	}
 	proxy.ConnectDial = dialerFromEnv(&proxy)
 	return &proxy


### PR DESCRIPTION
This patch solves the bug related to the "cannot write" error messages reported by several people. The problemd resided on the server connection not being closed when the client close its connection. I added a pipeAndClose() function that call to copyAndClose and is notified by channels. When one connection is closed the other is forced to close inmeditately.

Furthermore I added a couple of counters to ctx, it will serve to call a "onClosed" handler that can use this information (the next pull request).