### PR TITLE
Update deps in advance of code.google.com shutdown

### DIFF
--- a/ext/html/html.go
+++ b/ext/html/html.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 	"strings"
 
-	"code.google.com/p/go-charset/charset"
-	_ "code.google.com/p/go-charset/data"
+	"github.com/rogpeppe/go-charset/charset"
+	_ "github.com/rogpeppe/go-charset/data"
 	"github.com/elazarl/goproxy"
 )
 


### PR DESCRIPTION
Currently get warnings when getting `goproxy_html`.

```
warning: code.google.com is shutting down; import path code.google.com/p/go-charset/charset will stop working
warning: code.google.com is shutting down; import path code.google.com/p/go-charset/data will stop working
```

The author of `go-charset` has already moved to github, as evidenced by this commit:
https://github.com/rogpeppe/go-charset/commit/e9ff06f347d3f5d0013d59ed83754f0e88de10d4

