### PR TITLE
https: add support for ephemeral certificate generation (w/ ECDSA)

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -307,6 +307,21 @@ var AlwaysReject FuncHttpsHandler = func(host string, ctx *ProxyCtx) (*ConnectAc
 	return RejectConnect, host
 }
 
+// AlwaysMitmEphemeral is a HttpsHandler that always eavesdrop https connections, for example to
+// eavesdrop all https connections to www.google.com, we can use
+//	proxy.OnRequest(goproxy.ReqHostIs("www.google.com")).HandleConnect(goproxy.AlwaysMitmEphemeral)
+var AlwaysMitmEphemeral FuncHttpsHandler = func(host string, ctx *ProxyCtx) (*ConnectAction, string) {
+	return MitmConnectEphemeral, host
+}
+
+// AlwaysRejectEphemeral is a HttpsHandler that drops any CONNECT request, for example, this code will disallow
+// connections to hosts on any other port than 443
+//	proxy.OnRequest(goproxy.Not(goproxy.ReqHostMatches(regexp.MustCompile(":443$"))).
+//		HandleConnect(goproxy.AlwaysRejectEphemeral)
+var AlwaysRejectEphemeral FuncHttpsHandler = func(host string, ctx *ProxyCtx) (*ConnectAction, string) {
+	return RejectConnectEphemeral, host
+}
+
 // HandleBytes will return a RespHandler that read the entire body of the request
 // to a byte array in memory, would run the user supplied f function on the byte arra,
 // and will replace the body of the original response with the resulting byte array.


### PR DESCRIPTION
An unexported `signEphemeralHost` function produces a self-signed certificate for the hosts. It will use either P-256 if `ecdsaKey` is true or RSA with a 1024bit key otherwise.

An exported `TLSConfigEphemeral` function provides a `tls.Config` struct that will produce an ephemeral certificate during the tls handshake. It prefers ECDSA keys but will fall back to RSA if no ECDSA cipher suites are supported by the client. One generated the key is cached by placing it into the `Config.Certificates` array.

Each of `OkConnect`, `MitmConnect`, `HTTPMitmConnect`, `RejectConnect` has a corresponding ephemeral version `*Ephemeral`.

ECDSA keys are significantly faster to generate and sign with. This reduces the overhead of proxying https requests.

Similar functionality *could* be added to the existing `TLSConfigFromCA` and `signHost` functions but doing so would break compatibility.