### PR TITLE
prevent leaks by unblocking paired go routine

### DIFF
--- a/https.go
+++ b/https.go
@@ -263,7 +263,7 @@ func copyAndClose(ctx *ProxyCtx, w, r net.Conn) {
 		connOk = false
 		ctx.Warnf("Error copying to client: %s", err)
 	}
-	if err := r.Close(); err != nil && connOk {
+	if err := w.Close(); err != nil && connOk {
 		ctx.Warnf("Error closing: %s", err)
 	}
 }

--- a/proxy.go
+++ b/proxy.go
@@ -122,6 +122,7 @@ func (proxy *ProxyHttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 			ctx.Logf("Received response %v", resp.Status)
 		}
 		origBody := resp.Body
+		defer origBody.Close()
 		resp = proxy.filterResponse(resp, ctx)
 
 		ctx.Logf("Copying response to client %v [%d]", resp.Status, resp.StatusCode)


### PR DESCRIPTION
Closing the reader, can leave the pair go routine io.Copy hanging reading from the server net.Conn. By closing the writer, the io.Copy in the other routine will error out and unblock the goroutine. From debugging, proxy communications seems to happen this way:

1. Client: Hey Server
2. Server: I ack you
3. Client: send some data
4. Server: respond with data
5. Client: send some more data
6. Server: response with data
7. Client: close()
8. Server: hang

In other words, the server copy to client can hang forever under certain scenarios eventually causing the proxy to become unresponsive. I was able to reproduce this by chaining two proxies together, maybe it needs a test to simulate this tricky behavior?

