### PR TITLE
Close Body for MitM'ed connections

### DIFF
--- a/https.go
+++ b/https.go
@@ -200,6 +200,8 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 					ctx.Logf("resp %v", resp.Status)
 				}
 				resp = proxy.filterResponse(resp, ctx)
+				defer resp.Body.Close()
+
 				text := resp.Status
 				statusCode := strconv.Itoa(resp.StatusCode) + " "
 				if strings.HasPrefix(text, statusCode) {


### PR DESCRIPTION
Replaced body of responses which are processed via proxy.OnRequest().HandleConnect(goproxy.AlwaysMitm) are never closed.


