### PR TITLE
close response bodies for reuse in http package

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -123,7 +123,7 @@ func (proxy *ProxyHttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		}
 		origBody := resp.Body
 		resp = proxy.filterResponse(resp, ctx)
-
+		defer origBody.Close()
 		ctx.Logf("Copying response to client %v [%d]", resp.Status, resp.StatusCode)
 		// http.ResponseWriter will take care of filling the correct response length
 		// Setting it now, might impose wrong value, contradicting the actual new


### PR DESCRIPTION
HTTP responses should be closed when done using them. It can dramatically improve the performance of HTTP requests/responses.