### PR TITLE
Fix case where url.String() can return full url from opaque field

### DIFF
--- a/https.go
+++ b/https.go
@@ -180,7 +180,10 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 				}
 				req.RemoteAddr = r.RemoteAddr // since we're converting the request, need to carry over the original connecting IP as well
 				ctx.Logf("req %v", r.Host)
-				req.URL, err = url.Parse("https://" + r.Host + req.URL.String())
+
+				if !strings.Contains(req.URL.String(), "https://") {
+					req.URL, err = url.Parse("https://" + r.Host + req.URL.String())
+				}
 
 				// Bug fix which goproxy fails to provide request
 				// information URL in the context when does HTTPS MITM


### PR DESCRIPTION
We use goproxy for our acceptance tests at Geckoboard and had some issue whereby requests to googleapis have duplicated scheme and host in the logs. After pairing with @achilleasa we identified the issue to be coming from [here](https://github.com/jnormington/goproxy/blob/master/https.go#L183)

On further investigation it appears that if the Opaque field on the url.URL struct is not blank and you call String() it will return the opaque value instead as shown  [here](https://github.com/golang/go/blob/master/src/net/url/url.go#L673-L707). 

Meaning that we now could potentially have a clash of two schemes and hosts in the forwarding request through the proxy. Below is an example from the spec.

Here is an example from the spec showing the problem with proxy.Verbose set to true

```
2016/08/15 20:47:25 [001] INFO: Running 1 CONNECT handlers
2016/08/15 20:47:25 [001] INFO: on 0th handler: &{2 <nil> 0x943f0} example.com:443
2016/08/15 20:47:25 [001] INFO: Assuming CONNECT is TLS, mitm proxying it
2016/08/15 20:47:25 [001] INFO: signing for example.com
2016/08/15 20:47:25 [001] INFO: req example.com:443
2016/08/15 20:47:25 [001] INFO: Sending request GET https://example.com:443https://example.com
2016/08/15 20:47:25 [001] WARN: Cannot read TLS response from mitm'd server dial tcp: too many colons in address example.com:443https:
```

Specifically our example is from the googleapis you can see [here](https://github.com/google/google-api-go-client/blob/master/googleapi/googleapi.go#L298-L305) the setting of the Opaque field on the which is called from many of the apis in google services one such example is [here](https://github.com/google/google-api-go-client/blob/master/drive/v2/drive-gen.go#L5963) for retrieving a list of files from someones google drive.

This attempts to fix that by checking if the url.String() already contains https:// in the url and doesn't rewrite it if that is the case.

Thanks for your amazing work on supporting this project as well, we ❤️  goproxy