### PR TITLE
Fix issue caused but checking if string contains https:// before rewriting

### DIFF
--- a/https.go
+++ b/https.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -31,6 +32,7 @@ var (
 	MitmConnect     = &ConnectAction{Action: ConnectMitm, TLSConfig: TLSConfigFromCA(&GoproxyCa)}
 	HTTPMitmConnect = &ConnectAction{Action: ConnectHTTPMitm, TLSConfig: TLSConfigFromCA(&GoproxyCa)}
 	RejectConnect   = &ConnectAction{Action: ConnectReject, TLSConfig: TLSConfigFromCA(&GoproxyCa)}
+	httpsRegexp     = regexp.MustCompile(`^https:\/\/`)
 )
 
 type ConnectAction struct {
@@ -181,7 +183,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 				req.RemoteAddr = r.RemoteAddr // since we're converting the request, need to carry over the original connecting IP as well
 				ctx.Logf("req %v", r.Host)
 
-				if !strings.Contains(req.URL.String(), "https://") {
+				if !httpsRegexp.MatchString(req.URL.String()) {
 					req.URL, err = url.Parse("https://" + r.Host + req.URL.String())
 				}
 


### PR DESCRIPTION
Hey @elazarl,

Sorry I introduced another bug with the fix for opaque field - I didn't think it was possible to send a param with another url unencoded but that appears to not be the case, which when running the latest master of goproxy breaks some tests because of this change 😞 . As they have https:// in the url as a param that is not url encoded 😞  therefore when not an opaque field it bypasses rewriting the url.

```
2016-08-17_13:18:42.61837 2016/08/17 13:18:42 [049] INFO: Running 1 CONNECT handlers
2016-08-17_13:18:42.61838 2016/08/17 13:18:42 [049] INFO: on 0th handler: &{2 <nil> 0x536670} www.googleapis.com:443
2016-08-17_13:18:42.61850 2016/08/17 13:18:42 [049] INFO: Assuming CONNECT is TLS, mitm proxying it
2016-08-17_13:18:42.61853 2016/08/17 13:18:42 [049] INFO: signing for www.googleapis.com
2016-08-17_13:18:42.65652 2016/08/17 13:18:42 [049] INFO: ===> url after suppose rewrite /analytics/v3/management/accounts?scope=https://www.googleapis.com/auth/analytics.readonly%20https://www.googleapis.com/auth/userinfo.profile
2016-08-17_13:18:42.66825 2016/08/17 13:18:42 [047] INFO: resp 400 Bad Request
2016-08-17_13:18:42.66830 2016/08/17 13:18:42 [049] INFO: Exiting on EOF

```

This attempts to fix that - I understand it isn't perfect fix, and will look at option of using a cloned r instance in the coming weeks as per the other PR comms.
 