### PR TITLE
Fix `go vet` warnings

### DIFF
--- a/examples/goproxy-yui-minify/yui.go
+++ b/examples/goproxy-yui-minify/yui.go
@@ -76,7 +76,7 @@ func main() {
 			go func() {
 				defer stderr.Close()
 				const kb = 1024
-				msg, err := ioutil.ReadAll(&io.LimitedReader{stderr, 50 * kb})
+				msg, err := ioutil.ReadAll(&io.LimitedReader{R:stderr, N:50 * kb})
 				if len(msg) != 0 {
 					ctx.Logf("Error executing yuicompress: %s", string(msg))
 				}

--- a/https.go
+++ b/https.go
@@ -373,7 +373,7 @@ func (proxy *ProxyHttpServer) NewConnectDialToProxy(https_proxy string) func(net
 
 func TLSConfigFromCA(ca *tls.Certificate) func(host string, ctx *ProxyCtx) (*tls.Config, error) {
 	return func(host string, ctx *ProxyCtx) (*tls.Config, error) {
-		config := *defaultTLSConfig
+		config := defaultTLSConfig
 		ctx.Logf("signing for %s", stripPort(host))
 		cert, err := signHost(*ca, []string{stripPort(host)})
 		if err != nil {
@@ -381,6 +381,6 @@ func TLSConfigFromCA(ca *tls.Certificate) func(host string, ctx *ProxyCtx) (*tls
 			return nil, err
 		}
 		config.Certificates = append(config.Certificates, cert)
-		return &config, nil
+		return config, nil
 	}
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -502,9 +502,8 @@ func constantHttpServer(content []byte) (addr string) {
 	return l.Addr().String()
 }
 
-func TestIcyResponse(t *testing.T) {
+func xTestIcyResponse(t *testing.T) {
 	// TODO: fix this test
-	return // skip for now
 	s := constantHttpServer([]byte("ICY 200 OK\r\n\r\nblablabla"))
 	proxy := goproxy.NewProxyHttpServer()
 	proxy.Verbose = true

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // HTTP client implementation. See RFC 2616.
-// 
+//
 // This is the low-level Transport implementation of RoundTripper.
 // The high-level interface is in client.go.
 
@@ -305,7 +305,6 @@ func (t *Transport) getIdleConn(cm *connectMethod) (pconn *persistConn) {
 			return
 		}
 	}
-	return
 }
 
 func (t *Transport) dial(network, addr string) (c net.Conn, raddr string, ip *net.TCPAddr, err error) {
@@ -655,7 +654,6 @@ type requestAndChan struct {
 func (pc *persistConn) roundTrip(req *transportRequest) (resp *http.Response, err error) {
 	if pc.mutateHeaderFunc != nil {
 		panic("mutateHeaderFunc not supported in modified Transport")
-		pc.mutateHeaderFunc(req.extraHeaders())
 	}
 
 	// Ask for a compressed version if the caller didn't set their
@@ -664,7 +662,7 @@ func (pc *persistConn) roundTrip(req *transportRequest) (resp *http.Response, er
 	// requested it.
 	requestedGzip := false
 	if !pc.t.DisableCompression && req.Header.Get("Accept-Encoding") == "" {
-		// Request gzip only, not deflate. Deflate is ambiguous and 
+		// Request gzip only, not deflate. Deflate is ambiguous and
 		// not as universally supported anyway.
 		// See: http://www.gzip.org/zlib/zlib_faq.html#faq38
 		requestedGzip = true


### PR DESCRIPTION
These were noticed using Go 1.7. Earlier versions may not have had all
of these issues.
- https.go:376: assignment copies lock value to config:
  crypto/tls.Config contains sync.Once contains sync.Mutex
- examples/goproxy-yui-minify/yui.go:79: io.LimitedReader composite
  literal uses unkeyed fields
- proxy_test.go:508: unreachable code
- transport/transport.go:308: unreachable code
- transport/transport.go:658: unreachable code
