### PR TITLE
Increment session number for https requests also

### DIFF
--- a/https.go
+++ b/https.go
@@ -188,6 +188,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 			clientTlsReader := bufio.NewReader(rawClientTls)
 			for !isEof(clientTlsReader) {
 				req, err := http.ReadRequest(clientTlsReader)
+				var ctx = &ProxyCtx{Req: req, Session: atomic.AddInt64(&proxy.sess, 1), proxy: proxy}
 				if err != nil && err != io.EOF {
 					return
 				}


### PR DESCRIPTION
HTTPS requests share the same `ProxyCtx` struct per `CONNECT` session. 
With PR a `ProxyCtx` is created for each request over an open connection, providing the ability to distinguish the individual requests and responses in an HTTPS session.