### PR TITLE
Fix TestNoProxyHeaders and TestNoProxyHeadersHttps tests

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -89,6 +89,7 @@ func removeProxyHeaders(ctx *ProxyCtx, r *http.Request) {
 	//   options that are desired for that particular connection and MUST NOT
 	//   be communicated by proxies over further connections.
 	r.Header.Del("Connection")
+	r.Close = false
 }
 
 // Standard net/http function. Shouldn't be used directly, http.Serve will use it.


### PR DESCRIPTION
When the original request has a `Connection: close` header Go sets `r.Close` to true. When this is true Go adds the `Connection: close` header to the outgoing request even if the header was removed.

Fixes https://github.com/elazarl/goproxy/issues/92

This does mean that there is currently no way to make goproxy set a `Connection: close` header for its outgoing requests. I guess this could be made an option in `ProxyCtx` so you can change it in a request handler.
