### PR TITLE
support inbounce & outbounce bandwidth and #OnDone

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -55,3 +55,17 @@ type FuncHttpsHandler func(host string, ctx *ProxyCtx) (*ConnectAction, string)
 func (f FuncHttpsHandler) HandleConnect(host string, ctx *ProxyCtx) (*ConnectAction, string) {
 	return f(host, ctx)
 }
+
+// OnDone is called when a http request complete including https
+type DoneHandler interface {
+	Handle(ctx *ProxyCtx)
+}
+
+// A wrapper that would convert a function to a DoneHandler interface type
+type FuncDoneHandler func(ctx *ProxyCtx)
+
+// FuncDoneHandler.Handle(req,ctx) <=> FuncDoneHandler(req,ctx)
+func (f FuncDoneHandler) Handle(ctx *ProxyCtx) {
+	f(ctx)
+	return
+}

--- a/ctx.go
+++ b/ctx.go
@@ -22,6 +22,9 @@ type ProxyCtx struct {
 	// Will connect a request to a response
 	Session int64
 	proxy   *ProxyHttpServer
+	// Auth
+	Username string
+	Password string
 	// Bandwidth
 	Inbounce  int64
 	Outbounce int64

--- a/ctx.go
+++ b/ctx.go
@@ -3,6 +3,7 @@ package goproxy
 import (
 	"net/http"
 	"regexp"
+	"sync/atomic"
 )
 
 // ProxyCtx is the Proxy context, contains useful information about every request. It is passed to
@@ -21,6 +22,9 @@ type ProxyCtx struct {
 	// Will connect a request to a response
 	Session int64
 	proxy   *ProxyHttpServer
+	// Bandwidth
+	Inbounce  int64
+	Outbounce int64
 }
 
 type RoundTripper interface {
@@ -84,4 +88,13 @@ func (ctx *ProxyCtx) Charset() string {
 		return ""
 	}
 	return charsets[1]
+}
+
+// AddBandwidth set ctx Inbounce and Outbounce
+func (ctx *ProxyCtx) AddBandwidth(written int64, isInbounce bool) {
+	if isInbounce {
+		atomic.AddInt64(&ctx.Inbounce, written)
+		return
+	}
+	atomic.AddInt64(&ctx.Outbounce, written)
 }

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -323,3 +323,27 @@ func HandleBytes(f func(b []byte, ctx *ProxyCtx) []byte) RespHandler {
 		return resp
 	})
 }
+
+// DoneProxyConds has empty conditions now
+type DoneProxyConds struct {
+	proxy *ProxyHttpServer
+}
+
+// OnDone is called when a http request complete including https
+func (proxy *ProxyHttpServer) OnDone() *DoneProxyConds {
+	return &DoneProxyConds{proxy}
+}
+
+// DoFunc is equivalent to proxy.OnDone().Do(FuncDoneHandler(f))
+func (pcond *DoneProxyConds) DoFunc(f func(ctx *ProxyCtx)) {
+	pcond.Do(FuncDoneHandler(f))
+}
+
+// DoneProxyConds.Do will register the DoneHandler on the proxy
+func (pcond *DoneProxyConds) Do(h DoneHandler) {
+	pcond.proxy.doneHandlers = append(pcond.proxy.doneHandlers,
+		FuncDoneHandler(func(ctx *ProxyCtx) {
+			h.Handle(ctx)
+			return
+		}))
+}

--- a/https.go
+++ b/https.go
@@ -113,6 +113,8 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 				go copyAndClose(ctx, targetTCP, proxyClientTCP, true, &wg)
 				go copyAndClose(ctx, proxyClientTCP, targetTCP, false, &wg)
 				wg.Wait()
+
+				proxy.onDone(ctx)
 			} else {
 				var wg sync.WaitGroup
 				wg.Add(2)
@@ -121,6 +123,8 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 				wg.Wait()
 				proxyClient.Close()
 				targetSiteCon.Close()
+
+				proxy.onDone(ctx)
 			}
 		}()
 

--- a/https.go
+++ b/https.go
@@ -94,7 +94,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 		if !hasPort.MatchString(host) {
 			host += ":80"
 		}
-		targetSiteCon, err := proxy.connectDial("tcp", host)
+		targetSiteCon, err := ctx.connectDial("tcp", host)
 		if err != nil {
 			httpError(proxyClient, ctx, err)
 			return

--- a/https.go
+++ b/https.go
@@ -104,21 +104,25 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 
 		targetTCP, targetOK := targetSiteCon.(*net.TCPConn)
 		proxyClientTCP, clientOK := proxyClient.(*net.TCPConn)
-		if targetOK && clientOK {
-			go copyAndClose(ctx, targetTCP, proxyClientTCP)
-			go copyAndClose(ctx, proxyClientTCP, targetTCP)
-		} else {
-			go func() {
+
+		// start a goroutine to handle connections
+		go func() {
+			if targetOK && clientOK {
 				var wg sync.WaitGroup
 				wg.Add(2)
-				go copyOrWarn(ctx, targetSiteCon, proxyClient, &wg)
-				go copyOrWarn(ctx, proxyClient, targetSiteCon, &wg)
+				go copyAndClose(ctx, targetTCP, proxyClientTCP, true, &wg)
+				go copyAndClose(ctx, proxyClientTCP, targetTCP, false, &wg)
+				wg.Wait()
+			} else {
+				var wg sync.WaitGroup
+				wg.Add(2)
+				go copyOrWarn(ctx, targetSiteCon, proxyClient, true, &wg)
+				go copyOrWarn(ctx, proxyClient, targetSiteCon, false, &wg)
 				wg.Wait()
 				proxyClient.Close()
 				targetSiteCon.Close()
-
-			}()
-		}
+			}
+		}()
 
 	case ConnectHijack:
 		ctx.Logf("Hijacking CONNECT to %s", host)
@@ -286,20 +290,29 @@ func httpError(w io.WriteCloser, ctx *ProxyCtx, err error) {
 	}
 }
 
-func copyOrWarn(ctx *ProxyCtx, dst io.Writer, src io.Reader, wg *sync.WaitGroup) {
-	if _, err := io.Copy(dst, src); err != nil {
+func copyOrWarn(ctx *ProxyCtx, dst io.Writer, src io.Reader, isInbounce bool, wg *sync.WaitGroup) {
+	written, err := io.Copy(dst, src)
+	if err != nil {
 		ctx.Warnf("Error copying to client: %s", err)
 	}
+
+	ctx.AddBandwidth(written, isInbounce)
+
 	wg.Done()
 }
 
-func copyAndClose(ctx *ProxyCtx, dst, src *net.TCPConn) {
-	if _, err := io.Copy(dst, src); err != nil {
+func copyAndClose(ctx *ProxyCtx, dst, src *net.TCPConn, isInbounce bool, wg *sync.WaitGroup) {
+	written, err := io.Copy(dst, src)
+	if err != nil {
 		ctx.Warnf("Error copying to client: %s", err)
 	}
 
-	dst.CloseWrite()
-	src.CloseRead()
+	ctx.AddBandwidth(written, isInbounce)
+
+	err = dst.CloseWrite()
+	err = src.CloseRead()
+
+	wg.Done()
 }
 
 func dialerFromEnv(proxy *ProxyHttpServer) func(network, addr string) (net.Conn, error) {

--- a/proxy.go
+++ b/proxy.go
@@ -116,8 +116,11 @@ func (proxy *ProxyHttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		r, resp := proxy.filterRequest(r, ctx)
 
 		// bandwidth
-		dumpData, _ := httputil.DumpRequest(r, true)
-		ctx.AddBandwidth(int64(len(dumpData)), true)
+		var dumpData []byte
+		if r != nil {
+			dumpData, _ = httputil.DumpRequest(r, true)
+			ctx.AddBandwidth(int64(len(dumpData)), true)
+		}
 
 		if resp == nil {
 			removeProxyHeaders(ctx, r)

--- a/proxy.go
+++ b/proxy.go
@@ -132,10 +132,6 @@ func (proxy *ProxyHttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 					ctx.Logf("error read response %v %v:", r.URL.Host, err.Error())
 					http.Error(w, err.Error(), 500)
 
-					// bandwidth
-					dumpData, _ = httputil.DumpResponse(resp, true)
-					ctx.AddBandwidth(int64(len(dumpData)), false)
-
 					proxy.onDone(ctx)
 					return
 				}


### PR DESCRIPTION
Collect all the inbounce & outbounce bandwidth of http and https requests
This is real bandwidth, consist of the header and body not like the ``HandleBytes`` which only return the body of none ssl requests

Add ``#OnDone`` which will be trigger when a request done (http/https too)

So an example of bandwidth of all the request which go through our proxy:
```go
func main() {
	proxy := goproxy.NewProxyHttpServer()
	proxy.Verbose = true

	proxy.OnDone().DoFunc(func(ctx *goproxy.ProxyCtx) {
		fmt.Println("in :", ctx.Inbounce)
		fmt.Println("out:", ctx.Outbounce)
	})

	err := http.ListenAndServe(":9000", proxy)
	if err != nil {
		panic(err)
	}
}
```