### PR TITLE
Fix spelling error in ctx.go.

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -13,7 +13,7 @@ type ProxyCtx struct {
 	// Will contain the remote server's response (if available. nil if the request wasn't send yet)
 	Resp         *http.Response
 	RoundTripper RoundTripper
-	// will contain the recent error that occured while trying to send receive or parse traffic
+	// will contain the recent error that occurred while trying to send receive or parse traffic
 	Error error
 	// A handle for the user to keep data in the context, from the call of ReqHandler to the
 	// call of RespHandler


### PR DESCRIPTION
Change "occured" to "occurred".

Sorry for all the small little spelling fixes. I've been using your library in one of my projects, and the grammar freak in me seems to catch every little one. Great library, by the way!

Cheers,
Aaron ([insp3ctre](https://twitter.com/insp3ctre))