### PR TITLE
Allow ReqHandler to receive a request instance passed by the previous…

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -50,10 +50,12 @@ func isEof(r *bufio.Reader) bool {
 	return false
 }
 
-func (proxy *ProxyHttpServer) filterRequest(r *http.Request, ctx *ProxyCtx) (req *http.Request, resp *http.Response) {
-	req = r
+func (proxy *ProxyHttpServer) filterRequest(reqOrig *http.Request, ctx *ProxyCtx) (req *http.Request, resp *http.Response) {
+	req = reqOrig
+	ctx.Req = req
 	for _, h := range proxy.reqHandlers {
-		req, resp = h.Handle(r, ctx)
+		req, resp = h.Handle(req, ctx)
+		ctx.Req = req
 		// non-nil resp means the handler decided to skip sending the request
 		// and return canned response instead.
 		if resp != nil {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -3,6 +3,7 @@ package goproxy_test
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -121,6 +122,44 @@ func TestAlwaysHook(t *testing.T) {
 		req.URL.Path = "/bobo"
 		return req, nil
 	})
+	client, l := oneShotProxy(proxy, t)
+	defer l.Close()
+
+	if result := string(getOrFail(srv.URL+("/momo"), client, t)); result != "bobo" {
+		t.Error("Redirecting all requests from 127.0.0.1 to bobo, didn't work." +
+			" (Might break if Go's client sets RemoteAddr to IPv6 address). Got: " +
+			result)
+	}
+}
+
+func TestReplaceRequest(t *testing.T) {
+	type contextKey string
+	const testkey1 contextKey = "testkey1"
+	proxy := goproxy.NewProxyHttpServer()
+
+	proxy.OnRequest().DoFunc(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+		req.URL.Path = "/bobo"
+		oldCtx := req.Context()
+		newCtx := context.WithValue(oldCtx, testkey1, "testvalue1")
+		return req.WithContext(newCtx), nil
+	})
+	proxy.OnRequest().DoFunc(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+		if req.URL.Path != "/bobo" {
+			t.Error("The previous request is not provided")
+		}
+
+		if ctx.Req.URL.Path != "/bobo" {
+			t.Error("The previous request in ProxyCtx is not provided")
+		}
+
+		reqCtx := req.Context()
+		s, ok := reqCtx.Value(testkey1).(string)
+		if !ok || s != "testvalue1" {
+			t.Error("The previous context in the request is not provided")
+		}
+		return req, nil
+	})
+
 	client, l := oneShotProxy(proxy, t)
 	defer l.Close()
 


### PR DESCRIPTION
I think that filterRequest() has a potential problem.

It may return a new http.Request instance, say, in a case of its member context being replaced.
When filterRequest() has multiple request handlers, however, the second handler receives an original request "req O" instance, not a new instance "req A" returned by the first handler. Besides, the second handler cannot return "req A", which should be used in subsequent steps of ServerHTTP(), unless the first handler sets "req A" into ProxyCtx.

This patch solves this issue and updates ProxyCtx.Req behind the scenes.
