### PR TITLE
Close connections that are not net.TCPConn properly

### DIFF
--- a/https.go
+++ b/https.go
@@ -110,7 +110,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 		} else {
 			go func() {
 				var wg sync.WaitGroup
-				wg.Add(2)
+				wg.Add(1)
 				go copyOrWarn(ctx, targetSiteCon, proxyClient, &wg)
 				go copyOrWarn(ctx, proxyClient, targetSiteCon, &wg)
 				wg.Wait()


### PR DESCRIPTION
When using a Dialer that does not return net.Conn or net.TCPConn, connections are not closed properly when making an HTTP CONNECT request. This seems to stem from [https.go:113](https://github.com/elazarl/goproxy/blob/master/https.go#L113). It seems like the code is waiting for both connections to be closed before closing both connections. 
I fixed this in the pull request by changing the sync.WaitGroup to wait for one connection to close before closing the other one. Now the application will close the other end of the connection if either end closes their connection.