### PR TITLE
Send `Proxy-Connection: close` on unauthorized response

### DIFF
--- a/ext/auth/basic.go
+++ b/ext/auth/basic.go
@@ -15,11 +15,14 @@ var unauthorizedMsg = []byte("407 Proxy Authentication Required")
 func BasicUnauthorized(req *http.Request, realm string) *http.Response {
 	// TODO(elazar): verify realm is well formed
 	return &http.Response{
-		StatusCode:    407,
-		ProtoMajor:    1,
-		ProtoMinor:    1,
-		Request:       req,
-		Header:        http.Header{"Proxy-Authenticate": []string{"Basic realm=" + realm}},
+		StatusCode: 407,
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Request:    req,
+		Header: http.Header{
+			"Proxy-Authenticate": []string{"Basic realm=" + realm},
+			"Proxy-Connection":   []string{"close"},
+		},
 		Body:          ioutil.NopCloser(bytes.NewBuffer(unauthorizedMsg)),
 		ContentLength: int64(len(unauthorizedMsg)),
 	}


### PR DESCRIPTION
Hi!

Currently goproxy doesn't send any `Proxy-Connection` header in a HTTP 407 response, and the default HTTP/1.1 behaviour is to [keep the connection alive in that case](https://www.w3.org/Protocols/rfc2616/rfc2616-sec8.html).

However goproxy closes the connection, which breaks clients that expect to see a 407 response in order to negotiate the kind of HTTP authorization to send (Basic, NTLM, Digest), and then send a second request with proper `Proxy-Authorization`, because they expect the socket to be kept alive (as no `Proxy-Connection: close` is set, it's the default) and end up trying to write on a closed socket.

This fix adds the `Proxy-Connection: close` to 407 responses, however I'm not sure if it's the right place to put it.

Also I'm thinking ideally we would actually keep the socket alive but I'm not sure how hard that would be to implement.

Any thoughts?

Thanks!