### PR TITLE
Add possibility to install a cert store

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -1,6 +1,7 @@
 package goproxy
 
 import (
+	"crypto/tls"
 	"net/http"
 	"regexp"
 )
@@ -20,11 +21,17 @@ type ProxyCtx struct {
 	UserData interface{}
 	// Will connect a request to a response
 	Session int64
+	certStore CertStorage
 	proxy   *ProxyHttpServer
 }
 
 type RoundTripper interface {
 	RoundTrip(req *http.Request, ctx *ProxyCtx) (*http.Response, error)
+}
+
+type CertStorage interface {
+	Store(hostname string, cert *tls.Certificate)
+	Load(hostname string) *tls.Certificate
 }
 
 type RoundTripperFunc func(req *http.Request, ctx *ProxyCtx) (*http.Response, error)

--- a/proxy.go
+++ b/proxy.go
@@ -27,6 +27,7 @@ type ProxyHttpServer struct {
 	// ConnectDial will be used to create TCP connections for CONNECT requests
 	// if nil Tr.Dial will be used
 	ConnectDial func(network string, addr string) (net.Conn, error)
+	CertStore CertStorage
 }
 
 var hasPort = regexp.MustCompile(`:\d+$`)

--- a/signer.go
+++ b/signer.go
@@ -32,7 +32,7 @@ func hashSortedBigInt(lst []string) *big.Int {
 
 var goproxySignerVersion = ":goroxy1"
 
-func signHost(ca tls.Certificate, hosts []string) (cert tls.Certificate, err error) {
+func signHost(ca tls.Certificate, hosts []string) (cert *tls.Certificate, err error) {
 	var x509ca *x509.Certificate
 
 	// Use the provided ca and not the global GoproxyCa for certificate generation.
@@ -80,7 +80,7 @@ func signHost(ca tls.Certificate, hosts []string) (cert tls.Certificate, err err
 	if derBytes, err = x509.CreateCertificate(&csprng, &template, x509ca, &certpriv.PublicKey, ca.PrivateKey); err != nil {
 		return
 	}
-	return tls.Certificate{
+	return &tls.Certificate{
 		Certificate: [][]byte{derBytes, ca.Certificate[0]},
 		PrivateKey:  certpriv,
 	}, nil


### PR DESCRIPTION
Add the possibility to install a certificate storage to cache
certificates; this can make goproxy faster.