### PR TITLE
Allow proxy headers to passthrough

### DIFF
--- a/examples/cascadeproxy/main.go
+++ b/examples/cascadeproxy/main.go
@@ -64,6 +64,7 @@ func main() {
 	// start middle proxy server
 	middleProxy := goproxy.NewProxyHttpServer()
 	middleProxy.Verbose = true
+	middleProxy.KeepProxyHeaders = true
 	middleProxy.Tr.Proxy = func(req *http.Request) (*url.URL, error) {
 		return url.Parse("http://localhost:8082")
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -29,6 +29,8 @@ type ProxyHttpServer struct {
 	// ConnectDial will be used to create TCP connections for CONNECT requests
 	// if nil Tr.Dial will be used
 	ConnectDial func(network string, addr string) (net.Conn, error)
+	// allow proxy headers to pass
+	KeepProxyHeaders bool
 }
 
 var hasPort = regexp.MustCompile(`:\d+$`)
@@ -112,7 +114,9 @@ func (proxy *ProxyHttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		r, resp := proxy.filterRequest(r, ctx)
 
 		if resp == nil {
-			removeProxyHeaders(ctx, r)
+			if !proxy.KeepProxyHeaders {
+				removeProxyHeaders(ctx, r)
+			}
 			resp, err = ctx.RoundTrip(r)
 			if err != nil {
 				ctx.Error = err


### PR DESCRIPTION
Fixes #306

To test this, change

```diff
diff --git a/examples/cascadeproxy/main.go b/examples/cascadeproxy/main.go
index 194d03a..1bf3569 100644
--- a/examples/cascadeproxy/main.go
+++ b/examples/cascadeproxy/main.go
@@ -64,6 +64,7 @@ func main() {
        // start middle proxy server
        middleProxy := goproxy.NewProxyHttpServer()
        middleProxy.Verbose = true
+       middleProxy.KeepProxyHeaders = true
        middleProxy.Tr.Proxy = func(req *http.Request) (*url.URL, error) {
                return url.Parse("http://localhost:8082")
        }
@@ -82,7 +83,7 @@ func main() {
 
        // fire a http request: client --> middle proxy --> end proxy --> internet
        proxyUrl := "http://localhost:8081"
-       request, err := http.NewRequest("GET", "https://ip.cn", nil)
+       request, err := http.NewRequest("GET", "http://ip.cn", nil)
        if err != nil {
                log.Fatalf("new request failed:%v", err)
        }
```