### PR TITLE
random serial

### DIFF
--- a/signer.go
+++ b/signer.go
@@ -1,6 +1,7 @@
 package goproxy
 
 import (
+	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
 	"crypto/tls"
@@ -8,7 +9,6 @@ import (
 	"crypto/x509/pkix"
 	"math/big"
 	"net"
-	"runtime"
 	"sort"
 	"time"
 )
@@ -44,8 +44,12 @@ func signHost(ca tls.Certificate, hosts []string) (cert tls.Certificate, err err
 	if err != nil {
 		panic(err)
 	}
-	hash := hashSorted(append(hosts, goproxySignerVersion, ":"+runtime.Version()))
+	hash := make([]byte, 20)
 	serial := new(big.Int)
+	_, err = rand.Read(hash)
+	if err != nil {
+		panic(err)
+	}
 	serial.SetBytes(hash)
 	template := x509.Certificate{
 		// TODO(elazar): instead of this ugly hack, just encode the certificate and hash the binary form.


### PR DESCRIPTION
I am still experiencing the same issue with #311. The problem can be reproduced by:
1. start the proxy server
2. open firefox and view a hijacked page
3. restart the proxy server(which means all cached certificates at the server-side are cleared)
4. view the same page without closing the browser

I think the problem is cause by a misuse of hash for certificate serial number. As each time `signHost` is called, a different certificate is generated **but the serial is gonna be the same**, which would trigger an alert in Firefox.
I think it would be better to simply generate a random serial number.