### PR TITLE
Add KeepAcceptEncoding option, prevents proxy from changing Accept-Encoding sent by clients

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -80,7 +80,7 @@ func removeProxyHeaders(ctx *ProxyCtx, r *http.Request) {
 	ctx.Logf("Sending request %v %v", r.Method, r.URL.String())
 	// If no Accept-Encoding header exists, Transport will add the headers it can accept
 	// and would wrap the response body with the relevant reader.
-	r.Header.Del("Accept-Encoding")
+	// r.Header.Del("Accept-Encoding")
 	// curl can add that, see
 	// https://jdebp.eu./FGA/web-proxy-connection-header.html
 	r.Header.Del("Proxy-Connection")

--- a/proxy.go
+++ b/proxy.go
@@ -158,7 +158,7 @@ func NewProxyHttpServer() *ProxyHttpServer {
 		NonproxyHandler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			http.Error(w, "This is a proxy server. Does not respond to non-proxy requests.", 500)
 		}),
-		Tr: &http.Transport{TLSClientConfig: tlsClientSkipVerify, Proxy: http.ProxyFromEnvironment},
+		Tr: &http.Transport{TLSClientConfig: tlsClientSkipVerify, Proxy: http.ProxyFromEnvironment, DisableCompression: true},
 	}
 	proxy.ConnectDial = dialerFromEnv(&proxy)
 


### PR DESCRIPTION
Hi,

This PR adds a new flag to the proxy, `KeepAcceptEncoding`. When disabled, proxy behaviour remains the same to avoid breaking existing clients.

The default behaviour is that the Accept-Encoding header on client requests is removed. The proxy outbound transport will then add an "Accept-Encoding: gzip" header to outbound requests.

With `KeepAcceptEncoding` enabled the proxy will pass the header through. Note that if you want the proxy to *never* modify Accept-Encoding, you should also set `DisableCompression` true on the proxy outbound transport (otherwise it will ask for gzip when the client does not send the header).

Fixes https://github.com/elazarl/goproxy/issues/102 for me.