### PR TITLE
Added logger interface to allow usage of custom loggers

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,5 @@
+package goproxy
+
+type Logger interface {
+	Printf(format string, v ...interface{})
+}

--- a/proxy.go
+++ b/proxy.go
@@ -20,7 +20,7 @@ type ProxyHttpServer struct {
 	KeepDestinationHeaders bool
 	// setting Verbose to true will log information on each request sent to the proxy
 	Verbose         bool
-	Logger          *log.Logger
+	Logger          Logger
 	NonproxyHandler http.Handler
 	reqHandlers     []ReqHandler
 	respHandlers    []RespHandler


### PR DESCRIPTION
This change allows usage of custom logging libraries like logrus etc instead of go standard log library.
In my case needed for logging warnings in json format.