### PR TITLE
Pluggable certificate storage (following on from #284)

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -30,8 +30,7 @@ type RoundTripper interface {
 }
 
 type CertStorage interface {
-	Store(hostname string, cert *tls.Certificate)
-	Load(hostname string) *tls.Certificate
+	Fetch(hostname string, gen func() (*tls.Certificate, error)) (*tls.Certificate, error)
 }
 
 type RoundTripperFunc func(req *http.Request, ctx *ProxyCtx) (*http.Response, error)

--- a/ctx.go
+++ b/ctx.go
@@ -1,6 +1,7 @@
 package goproxy
 
 import (
+	"crypto/tls"
 	"net/http"
 	"regexp"
 )
@@ -19,12 +20,18 @@ type ProxyCtx struct {
 	// call of RespHandler
 	UserData interface{}
 	// Will connect a request to a response
-	Session int64
-	proxy   *ProxyHttpServer
+	Session   int64
+	certStore CertStorage
+	proxy     *ProxyHttpServer
 }
 
 type RoundTripper interface {
 	RoundTrip(req *http.Request, ctx *ProxyCtx) (*http.Response, error)
+}
+
+type CertStorage interface {
+	Store(hostname string, cert *tls.Certificate)
+	Load(hostname string) *tls.Certificate
 }
 
 type RoundTripperFunc func(req *http.Request, ctx *ProxyCtx) (*http.Response, error)

--- a/https.go
+++ b/https.go
@@ -65,7 +65,7 @@ func (proxy *ProxyHttpServer) connectDial(network, addr string) (c net.Conn, err
 }
 
 func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request) {
-	ctx := &ProxyCtx{Req: r, Session: atomic.AddInt64(&proxy.sess, 1), proxy: proxy}
+	ctx := &ProxyCtx{Req: r, Session: atomic.AddInt64(&proxy.sess, 1), proxy: proxy, certStore: proxy.CertStore}
 
 	hij, ok := w.(http.Hijacker)
 	if !ok {
@@ -408,14 +408,26 @@ func (proxy *ProxyHttpServer) NewConnectDialToProxyWithHandler(https_proxy strin
 
 func TLSConfigFromCA(ca *tls.Certificate) func(host string, ctx *ProxyCtx) (*tls.Config, error) {
 	return func(host string, ctx *ProxyCtx) (*tls.Config, error) {
+		var err error
+		var cert *tls.Certificate
+
+		hostname := stripPort(host)
 		config := *defaultTLSConfig
 		ctx.Logf("signing for %s", stripPort(host))
-		cert, err := signHost(*ca, []string{stripPort(host)})
-		if err != nil {
-			ctx.Warnf("Cannot sign host certificate with provided CA: %s", err)
-			return nil, err
+		if ctx.certStore != nil {
+			cert = ctx.certStore.Load(hostname)
 		}
-		config.Certificates = append(config.Certificates, cert)
+		if cert == nil {
+			cert, err = signHost(*ca, []string{hostname})
+			if err != nil {
+				ctx.Warnf("Cannot sign host certificate with provided CA: %s", err)
+				return nil, err
+			}
+			if ctx.certStore != nil {
+				ctx.certStore.Store(hostname, cert)
+			}
+		}
+		config.Certificates = append(config.Certificates, *cert)
 		return &config, nil
 	}
 }

--- a/https.go
+++ b/https.go
@@ -414,19 +414,21 @@ func TLSConfigFromCA(ca *tls.Certificate) func(host string, ctx *ProxyCtx) (*tls
 		hostname := stripPort(host)
 		config := *defaultTLSConfig
 		ctx.Logf("signing for %s", stripPort(host))
+
+		genCert := func() (*tls.Certificate, error) {
+			return signHost(*ca, []string{hostname})
+		}
 		if ctx.certStore != nil {
-			cert = ctx.certStore.Load(hostname)
+			cert, err = ctx.certStore.Fetch(hostname, genCert)
+		} else {
+			cert, err = genCert()
 		}
-		if cert == nil {
-			cert, err = signHost(*ca, []string{hostname})
-			if err != nil {
-				ctx.Warnf("Cannot sign host certificate with provided CA: %s", err)
-				return nil, err
-			}
-			if ctx.certStore != nil {
-				ctx.certStore.Store(hostname, cert)
-			}
+
+		if err != nil {
+			ctx.Warnf("Cannot sign host certificate with provided CA: %s", err)
+			return nil, err
 		}
+
 		config.Certificates = append(config.Certificates, *cert)
 		return &config, nil
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -29,6 +29,7 @@ type ProxyHttpServer struct {
 	// ConnectDial will be used to create TCP connections for CONNECT requests
 	// if nil Tr.Dial will be used
 	ConnectDial func(network string, addr string) (net.Conn, error)
+	CertStore   CertStorage
 }
 
 var hasPort = regexp.MustCompile(`:\d+$`)

--- a/signer.go
+++ b/signer.go
@@ -32,7 +32,7 @@ func hashSortedBigInt(lst []string) *big.Int {
 
 var goproxySignerVersion = ":goroxy1"
 
-func signHost(ca tls.Certificate, hosts []string) (cert tls.Certificate, err error) {
+func signHost(ca tls.Certificate, hosts []string) (cert *tls.Certificate, err error) {
 	var x509ca *x509.Certificate
 
 	// Use the provided ca and not the global GoproxyCa for certificate generation.
@@ -81,7 +81,7 @@ func signHost(ca tls.Certificate, hosts []string) (cert tls.Certificate, err err
 	if derBytes, err = x509.CreateCertificate(&csprng, &template, x509ca, &certpriv.PublicKey, ca.PrivateKey); err != nil {
 		return
 	}
-	return tls.Certificate{
+	return &tls.Certificate{
 		Certificate: [][]byte{derBytes, ca.Certificate[0]},
 		PrivateKey:  certpriv,
 	}, nil

--- a/signer_test.go
+++ b/signer_test.go
@@ -45,7 +45,7 @@ func TestSingerTls(t *testing.T) {
 	expected := "key verifies with Go"
 	server := httptest.NewUnstartedServer(ConstantHanlder(expected))
 	defer server.Close()
-	server.TLS = &tls.Config{Certificates: []tls.Certificate{cert, GoproxyCa}}
+	server.TLS = &tls.Config{Certificates: []tls.Certificate{*cert, GoproxyCa}}
 	server.TLS.BuildNameToCertificate()
 	server.StartTLS()
 	certpool := x509.NewCertPool()


### PR DESCRIPTION
*Duplicate of #330, which I accidentally opened from the wrong branch. Unfortunately there doesn't seem to be a way to change the source branch, so I've had to re-create the PR.*

<hr>

Following on from the work @btwotch did in #284, this builds on their PR to address @oec's [comment](https://github.com/elazarl/goproxy/pull/284#issuecomment-434281454) (I encountered a similar issue).

### Recap
To recap, the current implementation will regenerate TLS certificates every request. Generating certificates is computationally expensive, so this leads to performance issues when there are many requests to the same host.

@btwotch made it possible to add a custom certificate store to alleviate this issue. However, multiple concurrent requests to the same host would result in the certificate being generated multiple times in parallel.

### Changes in this PR
This PR adapts the certificate store's interface. Rather than having `Store()` and `Load()` as separate functions, a single function - `Fetch()` is provided with the cache key (hostname) and a function that returns the certificate to cache, and it handles the storage and retrieval internally.

While a simple storage implementation may mimic the previous behaviour (leaving the described problem in place), an alternative implementation of the certificate storage might take a lock on the 
hostname when generating the certificate, meaning only one certificate will be generated and other clients will wait until it is present in the store.

### Benchmark
Using a simple in-memory certificate store that takes a lock for each hostname while generating the certificate, I got the following results from some simple load testing using [vegeta](https://github.com/tsenart/vegeta).

#### Without the certificate store
Note the mean latency of **1.3s**, p99 latency of **11.8s**, and success rate of **11.2%**.

```
Requests      [total, rate]            250, 50.17
Duration      [total, attack, wait]    17.624958347s, 4.983325s, 12.641633347s
Latencies     [mean, 50, 95, 99, max]  1.262955939s, 0s, 11.787397416s, 13.733232781s, 14.133813748s
Bytes In      [total, mean]            315096, 1260.38
Bytes Out     [total, mean]            0, 0.00
Success       [ratio]                  11.20%
Status Codes  [code:count]             0:222  200:28
```

#### With the certificate store
Note the mean latency of **0.3s**, p99 latency of **0.8ms**, and success rate of **99.6**. Quite an improvement!

```
Requests      [total, rate]            250, 50.13
Duration      [total, attack, wait]    5.257647755s, 4.987435s, 270.212755ms
Latencies     [mean, 50, 95, 99, max]  305.004131ms, 193.990013ms, 780.066772ms, 842.741389ms, 857.624176ms
Bytes In      [total, mean]            2796573, 11186.29
Bytes Out     [total, mean]            0, 0.00
Success       [ratio]                  99.60%
Status Codes  [code:count]             0:1  200:249
```

Credit to @btwotch for the foundation of this PR - their original commit was cherry-picked and used as the starting point.

If you think it'd be valuable, I'd also be happy to add a PR to include the in-memory storage implementation I described in [this comment](https://github.com/elazarl/goproxy/pull/330#issuecomment-478301141).