### PR TITLE
Close non-persistent HTTPS connections

### DIFF
--- a/https.go
+++ b/https.go
@@ -261,6 +261,11 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 					ctx.Warnf("Cannot write TLS response chunked trailer from mitm'd client: %v", err)
 					return
 				}
+
+				if req.Close {
+					ctx.Logf("Non-persistent connection; closing")
+					return
+				}
 			}
 			ctx.Logf("Exiting on EOF")
 		}()


### PR DESCRIPTION
For instance, connections with the "Connection: close" header. Currently, if the client uses this header to signal a non-persistent connection and waits for the connection to be closed, it will hang indefinitely. This change closes these connections after processing the first HTTP request.