### PR TITLE
 Do not modify headers in response to a HEAD request

### DIFF
--- a/https.go
+++ b/https.go
@@ -234,32 +234,44 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 					ctx.Warnf("Cannot write TLS response HTTP status from mitm'd client: %v", err)
 					return
 				}
-				// Since we don't know the length of resp, return chunked encoded response
-				// TODO: use a more reasonable scheme
-				resp.Header.Del("Content-Length")
-				resp.Header.Set("Transfer-Encoding", "chunked")
-				// Force connection close otherwise chrome will keep CONNECT tunnel open forever
-				resp.Header.Set("Connection", "close")
-				if err := resp.Header.Write(rawClientTls); err != nil {
-					ctx.Warnf("Cannot write TLS response header from mitm'd client: %v", err)
-					return
-				}
-				if _, err = io.WriteString(rawClientTls, "\r\n"); err != nil {
-					ctx.Warnf("Cannot write TLS response header end from mitm'd client: %v", err)
-					return
-				}
-				chunked := newChunkedWriter(rawClientTls)
-				if _, err := io.Copy(chunked, resp.Body); err != nil {
-					ctx.Warnf("Cannot write TLS response body from mitm'd client: %v", err)
-					return
-				}
-				if err := chunked.Close(); err != nil {
-					ctx.Warnf("Cannot write TLS chunked EOF from mitm'd client: %v", err)
-					return
-				}
-				if _, err = io.WriteString(rawClientTls, "\r\n"); err != nil {
-					ctx.Warnf("Cannot write TLS response chunked trailer from mitm'd client: %v", err)
-					return
+				if req.Method == "HEAD" {
+					// If this was a HEAD request, there should be no body, so just return the headers unchanged
+					if err := resp.Header.Write(rawClientTls); err != nil {
+						ctx.Warnf("Cannot write TLS response header from mitm'd client: %v", err)
+						return
+					}
+					if _, err = io.WriteString(rawClientTls, "\r\n"); err != nil {
+						ctx.Warnf("Cannot write TLS response header end from mitm'd client: %v", err)
+						return
+					}
+				} else {
+					// Since we don't know the length of resp, return chunked encoded response
+					// TODO: use a more reasonable scheme
+					resp.Header.Del("Content-Length")
+					resp.Header.Set("Transfer-Encoding", "chunked")
+					// Force connection close otherwise chrome will keep CONNECT tunnel open forever
+					resp.Header.Set("Connection", "close")
+					if err := resp.Header.Write(rawClientTls); err != nil {
+						ctx.Warnf("Cannot write TLS response header from mitm'd client: %v", err)
+						return
+					}
+					if _, err = io.WriteString(rawClientTls, "\r\n"); err != nil {
+						ctx.Warnf("Cannot write TLS response header end from mitm'd client: %v", err)
+						return
+					}
+					chunked := newChunkedWriter(rawClientTls)
+					if _, err := io.Copy(chunked, resp.Body); err != nil {
+						ctx.Warnf("Cannot write TLS response body from mitm'd client: %v", err)
+						return
+					}
+					if err := chunked.Close(); err != nil {
+						ctx.Warnf("Cannot write TLS chunked EOF from mitm'd client: %v", err)
+						return
+					}
+					if _, err = io.WriteString(rawClientTls, "\r\n"); err != nil {
+						ctx.Warnf("Cannot write TLS response chunked trailer from mitm'd client: %v", err)
+						return
+					}
 				}
 			}
 			ctx.Logf("Exiting on EOF")

--- a/https.go
+++ b/https.go
@@ -234,7 +234,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 					ctx.Warnf("Cannot write TLS response HTTP status from mitm'd client: %v", err)
 					return
 				}
-				if req.Method == "HEAD" {
+				if req != nil && req.Method == "HEAD" {
 					// If this was a HEAD request, there should be no body, so just return the headers unchanged
 					if err := resp.Header.Write(rawClientTls); err != nil {
 						ctx.Warnf("Cannot write TLS response header from mitm'd client: %v", err)


### PR DESCRIPTION
Currently GoProxy always removes the `Content-Length` header from any response, and replaces the body with chunked encoding. This does not really make sense to apply to `HEAD` requests, which will have no body in the response, and may rely on the `Content-Length` being returned.

Use-case: The Docker Registry API sends a `HEAD` request to determine if a blob for a particular layer already exists in the repository. It expects that, if the blob exists, the response will be a `200 OK` and will contain a `Content-Length` header indicating the size of the blob. If GoProxy strips the header, then Docker thinks that the blob does not exist, and always tries to reupload every blob. This change allows GoProxy to correctly proxy the Docker Registry API.