### PR TITLE
Adds cache for MITM signing to speed up repeat proxy requests.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/elazarl/goproxy
+
+go 1.12


### PR DESCRIPTION
The goal of this PR was to reduce the number of times the proxy generated a leaf certificate for a website.

Feel free to pick it apart. I am using it in our custom version, so I thought I would create a PR to bring it upstream if it's useful.