### PR TITLE
Random cert serial

### DIFF
--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1,2 +1,4 @@
+github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/inconshreveable/go-vhost v0.0.0-20160627193104-06d84117953b h1:IpLPmn6Re21F0MaV6Zsc5RdSE6KuoFpWmHiUSEs3PrE=
 github.com/inconshreveable/go-vhost v0.0.0-20160627193104-06d84117953b/go.mod h1:aA6DnFhALT3zH0y+A39we+zbrdMC2N0X/q21e6FI0LU=
+github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/elazarl/goproxy
+
+require github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 h1:dWB6v3RcOy03t/bUadywsbyrQwCqZeNIEX6M1OtSZOM=
+github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
+github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=


### PR DESCRIPTION
Creates a random certificate serial for each generated certificate. This prevents browsers seeing the same serial, for the same host, in two different certificates.

It is sufficient to use non-cryptographic random numbers for this task, hence the use of `math/rand`. If deterministic behaviour is needed (e.g. in tests), `rand.Seed()` can be called again.

This PR also includes some unavoidable changes to go.mod/go.sum files, without which the project cannot build (at least with Go 1.12).

Fixes #311.