### PR TITLE
MITM: recreating private/public keys all the time

### DIFF
--- a/signer.go
+++ b/signer.go
@@ -13,10 +13,13 @@ import (
 	"fmt"
 	"math/big"
 	mathrand "math/rand"
+	"runtime"
 	"net"
 	"sort"
+	"strings"
 	"time"
 	"github.com/patrickmn/go-cache"
+	"sync/atomic"
 )
 
 func hashSorted(lst []string) []byte {
@@ -40,20 +43,19 @@ var goproxySignerVersion = ":goroxy1"
 var certprivRSA crypto.Signer
 var certprivECDSA crypto.Signer
 var crtCache = cache.New(20*time.Minute, 10*time.Minute)
+var serialCA uint64 = 9999
 
 func signHost(ca tls.Certificate, hosts []string) (cert *tls.Certificate, err error) {
-
-	value, exist := crtCache.Get(hosts[0])
+	key := strings.Join(hosts[:], "/")
+	value, exist := crtCache.Get(key)
 	if exist {
 		cert = value.(*tls.Certificate)
 		return
 	}
 
-	cert, err = generateCertificate(ca, hosts)
+    cert, err = generateCertificate(ca, hosts)
 
-	for _, host := range hosts {
-		crtCache.Add(host, cert, cache.DefaultExpiration)
-	}
+	crtCache.Add(key, cert, cache.DefaultExpiration)
 
 	return
 }
@@ -71,10 +73,9 @@ func generateCertificate(ca tls.Certificate, hosts []string) (cert *tls.Certific
 		panic(err)
 	}
 
-	serial := big.NewInt(mathrand.Int63())
 	template := x509.Certificate{
 		// TODO(elazar): instead of this ugly hack, just encode the certificate and hash the binary form.
-		SerialNumber: serial,
+		SerialNumber: new(big.Int).SetUint64(atomic.AddUint64(&serialCA, 1)),
 		Issuer:       x509ca.Subject,
 		Subject: pkix.Name{
 			Organization: []string{"GoProxy untrusted MITM proxy Inc"},
@@ -117,7 +118,76 @@ func generateCertificate(ca tls.Certificate, hosts []string) (cert *tls.Certific
 	}, nil
 }
 
+
+func signHostOld(ca tls.Certificate, hosts []string) (cert *tls.Certificate, err error) {
+	var x509ca *x509.Certificate
+
+	// Use the provided ca and not the global GoproxyCa for certificate generation.
+	if x509ca, err = x509.ParseCertificate(ca.Certificate[0]); err != nil {
+		return
+	}
+	start := time.Unix(0, 0)
+	end, err := time.Parse("2006-01-02", "2049-12-31")
+	if err != nil {
+		panic(err)
+	}
+
+	serial := big.NewInt(mathrand.Int63())
+	template := x509.Certificate{
+		// TODO(elazar): instead of this ugly hack, just encode the certificate and hash the binary form.
+		SerialNumber: serial,
+		Issuer:       x509ca.Subject,
+		Subject: pkix.Name{
+			Organization: []string{"GoProxy untrusted MITM proxy Inc"},
+		},
+		NotBefore: start,
+		NotAfter:  end,
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	for _, h := range hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			template.IPAddresses = append(template.IPAddresses, ip)
+		} else {
+			template.DNSNames = append(template.DNSNames, h)
+			template.Subject.CommonName = h
+		}
+	}
+
+	hash := hashSorted(append(hosts, goproxySignerVersion, ":" + runtime.Version()))
+	var csprng CounterEncryptorRand
+	if csprng, err = NewCounterEncryptorRandFromKey(ca.PrivateKey, hash); err != nil {
+		return
+	}
+
+	var certpriv crypto.Signer
+	switch ca.PrivateKey.(type) {
+	case *rsa.PrivateKey:
+		if certpriv, err = rsa.GenerateKey(&csprng, 2048); err != nil {
+			return
+		}
+	case *ecdsa.PrivateKey:
+		if certpriv, err = ecdsa.GenerateKey(elliptic.P256(), &csprng); err != nil {
+			return
+		}
+	default:
+		err = fmt.Errorf("unsupported key type %T", ca.PrivateKey)
+	}
+
+	var derBytes []byte
+	if derBytes, err = x509.CreateCertificate(&csprng, &template, x509ca, certpriv.Public(), ca.PrivateKey); err != nil {
+		return
+	}
+	return &tls.Certificate{
+		Certificate: [][]byte{derBytes, ca.Certificate[0]},
+		PrivateKey:  certpriv,
+	}, nil
+}
+
 func init() {
+	serialCA = uint64(time.Now().Unix() * 1000000000)
 	certprivRSA, _ = rsa.GenerateKey(rand.Reader, 2048);
 	certprivECDSA, _ = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 }


### PR DESCRIPTION
... has huge impact on speed of processing, with this change the RSA and ECDSA keys are created within "init()" and used when needed. This is quick fix, please set it to some configuration variable if you consider that it is useful to generate them on each request. I dont think this would impact the security on client side. 