### PR TITLE
Don't return http 200 for ConnectHijack actions

### DIFF
--- a/https.go
+++ b/https.go
@@ -36,6 +36,10 @@ var (
 	httpsRegexp     = regexp.MustCompile(`^https:\/\/`)
 )
 
+// ConnectAction enables the caller to override the standard connect flow.
+// When Action is ConnectHijack, it is up to the implementer to send the 
+// HTTP 200, or any other valid http response back to the client from within the 
+// Hijack func
 type ConnectAction struct {
 	Action    ConnectActionLiteral
 	Hijack    func(req *http.Request, client net.Conn, ctx *ProxyCtx)
@@ -129,8 +133,6 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 		}
 
 	case ConnectHijack:
-		ctx.Logf("Hijacking CONNECT to %s", host)
-		proxyClient.Write([]byte("HTTP/1.0 200 OK\r\n\r\n"))
 		todo.Hijack(r, proxyClient, ctx)
 	case ConnectHTTPMitm:
 		proxyClient.Write([]byte("HTTP/1.0 200 OK\r\n\r\n"))


### PR DESCRIPTION
#376  
Sending HTTP 200 to the client connection before invoking the todo.Hijack() method for a ConnectHijack action makes it impossible to cascade the http 502 (or any other error) back to the client in case we wanted to abort prematurely (e.g. the target address is unavailable)

[RFC 2817](https://tools.ietf.org/html/rfc2817#section-5.3) States: 

```
5.3 Establishing a Tunnel with CONNECT

   Any successful (2xx) response to a CONNECT request indicates that the
   proxy has established a connection to the requested host and port,
   and has switched to tunneling the current connection to that server
   connection.
```

It should be therefore up to the Hijack() method implementer to send the http 200 upon confirming that we can establish a tunnel.