### PR TITLE
Forgot that this isn't a library like it was in my fork

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -163,12 +163,12 @@ func ContentTypeIs(typ string, types ...string) RespCondition {
 
 // StatusCodeIs returns a RespCondition, testing whether or not the HTTP status
 // code is one of the given ints
-func StatusCodeIs(codes ...int) goproxy.RespCondition {
+func StatusCodeIs(codes ...int) RespCondition {
 	codeSet := make(map[int]bool)
 	for _, c := range codes {
 		codeSet[c] = true
 	}
-	return goproxy.RespConditionFunc(func(resp *http.Response, ctx *goproxy.ProxyCtx) bool {
+	return RespConditionFunc(func(resp *http.Response, ctx *ProxyCtx) bool {
 		if resp == nil {
 			return false
 		}


### PR DESCRIPTION
Sorry about that! I added this method in a project that imported goproxy and figured I'd contribute it back... I forgot to remove the fully qualified method name.