### PR TITLE
adresses  #306, adds late handlers in proxy to enable flexible setting o

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -201,6 +201,26 @@ func (pcond *ReqProxyConds) Do(h ReqHandler) {
 		}))
 }
 
+// ReqProxyConds.DoLate will register late ReqHandler on the proxy that are run after resetting request headers
+// the ReqHandler will handle the HTTP request if all the conditions
+// aggregated in the ReqProxyConds are met. Typical usage:
+//	proxy.OnRequest().Do(handler) // will call handler.Handle(req,ctx) on every request to the proxy
+//	proxy.OnRequest(cond1,cond2).Do(handler)
+//	// given request to the proxy, will test if cond1.HandleReq(req,ctx) && cond2.HandleReq(req,ctx) are true
+//	// if they are, will call handler.Handle(req,ctx)
+func (pcond *ReqProxyConds) DoLate(h ReqHandler) {
+	pcond.proxy.lateReqHandlers = append(pcond.proxy.reqHandlers,
+		FuncReqHandler(func(r *http.Request, ctx *ProxyCtx) (*http.Request, *http.Response) {
+			for _, cond := range pcond.reqConds {
+				if !cond.HandleReq(r, ctx) {
+					return r, nil
+				}
+			}
+			return h.Handle(r, ctx)
+		}))
+}
+
+
 // HandleConnect is used when proxy receives an HTTP CONNECT request,
 // it'll then use the HttpsHandler to determine what should it
 // do with this request. The handler returns a ConnectAction struct, the Action field in the ConnectAction

--- a/examples/cascadeproxyauth/main.go
+++ b/examples/cascadeproxyauth/main.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/elazarl/goproxy/ext/auth"
+
+	"github.com/elazarl/goproxy"
+)
+
+const (
+	ProxyAuthHeader = "Proxy-Authorization"
+)
+
+func SetBasicAuth(username, password string, req *http.Request) {
+	req.Header.Set(ProxyAuthHeader, fmt.Sprintf("Basic %s", basicAuth(username, password)))
+}
+
+func basicAuth(username, password string) string {
+	return base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+}
+
+func GetBasicAuth(req *http.Request) (username, password string, ok bool) {
+	auth := req.Header.Get(ProxyAuthHeader)
+	if auth == "" {
+		return
+	}
+
+	const prefix = "Basic "
+	if !strings.HasPrefix(auth, prefix) {
+		return
+	}
+	c, err := base64.StdEncoding.DecodeString(auth[len(prefix):])
+	if err != nil {
+		return
+	}
+	cs := string(c)
+	s := strings.IndexByte(cs, ':')
+	if s < 0 {
+		return
+	}
+	return cs[:s], cs[s+1:], true
+}
+
+func main() {
+	username, password := "foo", "bar"
+
+	// start end proxy server
+	endProxy := goproxy.NewProxyHttpServer()
+	endProxy.Verbose = true
+	auth.ProxyBasic(endProxy, "my_realm", func(user, pwd string) bool {
+		return user == username && password == pwd
+	})
+	log.Println("serving end proxy server at localhost:8082")
+	go http.ListenAndServe("localhost:8082", endProxy)
+
+	// start middle proxy server
+	middleProxy := goproxy.NewProxyHttpServer()
+	middleProxy.Verbose = true
+	middleProxy.Tr.Proxy = func(req *http.Request) (*url.URL, error) {
+		return url.Parse("http://localhost:8082")
+	}
+	connectReqHandler := func(req *http.Request) {
+		SetBasicAuth(username, password, req)
+	}
+	middleProxy.ConnectDial = middleProxy.NewConnectDialToProxyWithHandler("http://localhost:8082", connectReqHandler)
+	middleProxy.OnRequest().DoLate(goproxy.FuncReqHandler(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+		SetBasicAuth(username, password, req)
+		return req, nil
+	}))
+	log.Println("serving middle proxy server at localhost:8081")
+	go http.ListenAndServe("localhost:8081", middleProxy)
+
+	time.Sleep(1 * time.Second)
+
+	// fire a http request: client --> middle proxy --> end proxy --> internet
+	proxyUrl := "http://localhost:8081"
+	request, err := http.NewRequest("GET", "https://ip.cn", nil)
+	if err != nil {
+		log.Fatalf("new request failed:%v", err)
+	}
+	tr := &http.Transport{Proxy: func(req *http.Request) (*url.URL, error) { return url.Parse(proxyUrl) }}
+	client := &http.Client{Transport: tr}
+	rsp, err := client.Do(request)
+	if err != nil {
+		log.Fatalf("get rsp failed:%v", err)
+
+	}
+	defer rsp.Body.Close()
+	data, _ := ioutil.ReadAll(rsp.Body)
+
+	if rsp.StatusCode != http.StatusOK {
+		log.Fatalf("status %d, data %s", rsp.StatusCode, data)
+	}
+
+	log.Printf("rsp:%s", data)
+}

--- a/examples/cascadeproxymiddleauth/main.go
+++ b/examples/cascadeproxymiddleauth/main.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	// "github.com/elazarl/goproxy/ext/auth"
+
+	"github.com/elazarl/goproxy"
+)
+
+const (
+	ProxyAuthHeader = "Proxy-Authorization"
+)
+
+func SetBasicAuth(username, password string, req *http.Request) {
+	req.Header.Set(ProxyAuthHeader, fmt.Sprintf("Basic %s", basicAuth(username, password)))
+}
+
+func basicAuth(username, password string) string {
+	return base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+}
+
+func GetBasicAuth(req *http.Request) (username, password string, ok bool) {
+	auth := req.Header.Get(ProxyAuthHeader)
+	if auth == "" {
+		return
+	}
+
+	const prefix = "Basic "
+	if !strings.HasPrefix(auth, prefix) {
+		return
+	}
+	c, err := base64.StdEncoding.DecodeString(auth[len(prefix):])
+	if err != nil {
+		return
+	}
+	cs := string(c)
+	s := strings.IndexByte(cs, ':')
+	if s < 0 {
+		return
+	}
+	return cs[:s], cs[s+1:], true
+}
+
+func main() {
+	// we want basic auth credentials to reach the end proxy, so as they are dropped
+	// we have to inject them into the middle proxy but late, otherwise the headers are removed by any proxy
+
+	username, password := "foo", "bar"
+
+	// start end proxy server
+	endProxy := goproxy.NewProxyHttpServer()
+	endProxy.Verbose = true
+	/*
+		auth.ProxyBasic(endProxy, "my_realm", func(user, pwd string) bool {
+			return user == username && password == pwd
+		})
+	*/
+	endProxy.OnRequest().Do(goproxy.FuncReqHandler(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+		log.Println("headers arriving at end proxy are: ", req.Header)
+		return req, nil
+	}))
+	log.Println("serving end proxy server at localhost:8082")
+	go http.ListenAndServe("localhost:8082", endProxy)
+
+	// start middle proxy server
+	middleProxy := goproxy.NewProxyHttpServer()
+	middleProxy.Verbose = true
+	middleProxy.Tr.Proxy = func(req *http.Request) (*url.URL, error) {
+		return url.Parse("http://localhost:8082")
+	}
+	connectReqHandler := func(req *http.Request) {
+		SetBasicAuth(username, password, req)
+	}
+	middleProxy.ConnectDial = middleProxy.NewConnectDialToProxyWithHandler("http://localhost:8082", connectReqHandler)
+	middleProxy.OnRequest().DoLate(goproxy.FuncReqHandler(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+		log.Println("Setting basic auth headers on outbound request")
+		SetBasicAuth(username, password, req)
+		return req, nil
+	}))
+	log.Println("serving middle proxy server at localhost:8081")
+	go http.ListenAndServe("localhost:8081", middleProxy)
+
+	time.Sleep(1 * time.Second)
+
+	// fire a http request: client --> middle proxy --> end proxy --> internet
+	proxyUrl := "http://localhost:8081"
+	request, err := http.NewRequest("GET", "http://httpbin.org/ip", nil)
+	if err != nil {
+		log.Fatalf("new request failed:%v", err)
+	}
+	tr := &http.Transport{Proxy: func(req *http.Request) (*url.URL, error) { return url.Parse(proxyUrl) }}
+	client := &http.Client{Transport: tr}
+	rsp, err := client.Do(request)
+	if err != nil {
+		log.Fatalf("get rsp failed:%v", err)
+
+	}
+	defer rsp.Body.Close()
+	data, _ := ioutil.ReadAll(rsp.Body)
+
+	if rsp.StatusCode != http.StatusOK {
+		log.Fatalf("status %d, data %s", rsp.StatusCode, data)
+	}
+
+	log.Printf("rsp:%s", data)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/elazarl/goproxy
 
 require github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2
+
+go 1.13

--- a/proxy.go
+++ b/proxy.go
@@ -138,7 +138,7 @@ func (proxy *ProxyHttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 			r, resp := proxy.lateFilterRequest(r, ctx)
 
-			if resp == nil {
+			if resp != nil {
 				ctx.Logf("late request handlers should not drop requests")
 				return
 			}

--- a/proxy.go
+++ b/proxy.go
@@ -24,7 +24,7 @@ type ProxyHttpServer struct {
 	NonproxyHandler http.Handler
 	reqHandlers     []ReqHandler
 	// lateRequestHandlers => those run privileged after hop headers have been removed
-	lateReqHandlers    []ReqHandler
+	lateReqHandlers []ReqHandler
 	respHandlers    []RespHandler
 	httpsHandlers   []HttpsHandler
 	Tr              *http.Transport
@@ -193,12 +193,12 @@ func (proxy *ProxyHttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 // NewProxyHttpServer creates and returns a proxy server, logging to stderr by default
 func NewProxyHttpServer() *ProxyHttpServer {
 	proxy := ProxyHttpServer{
-		Logger:           log.New(os.Stderr, "", log.LstdFlags),
-		reqHandlers:      []ReqHandler{},
-		lateReqHandlers:  []ReqHandler{},
-		respHandlers:     []RespHandler{},
-		httpsHandlers:    []HttpsHandler{},
-		NonproxyHandler:  http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		Logger:          log.New(os.Stderr, "", log.LstdFlags),
+		reqHandlers:     []ReqHandler{},
+		lateReqHandlers: []ReqHandler{},
+		respHandlers:    []RespHandler{},
+		httpsHandlers:   []HttpsHandler{},
+		NonproxyHandler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			http.Error(w, "This is a proxy server. Does not respond to non-proxy requests.", 500)
 		}),
 		Tr: &http.Transport{TLSClientConfig: tlsClientSkipVerify, Proxy: http.ProxyFromEnvironment},


### PR DESCRIPTION
auth headers are stripped after request handlers are processed, added outbound handler chain to reset or set new header variables after deleting the inbound ones at the hop, added an example to use, this addresses the headers not getting through to the end proxy in the examples