### PR TITLE
Allow setting ConnectDial on context

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -2,6 +2,7 @@ package goproxy
 
 import (
 	"crypto/tls"
+	"net"
 	"net/http"
 	"regexp"
 )
@@ -13,7 +14,10 @@ type ProxyCtx struct {
 	Req *http.Request
 	// Will contain the remote server's response (if available. nil if the request wasn't send yet)
 	Resp         *http.Response
+	// Can be used to override the RoundTripper for a single request.
 	RoundTripper RoundTripper
+	// Can be used to override the ConnectDial for a single request.
+	ConnectDial func(network, addr string) (net.Conn, error)
 	// will contain the recent error that occurred while trying to send receive or parse traffic
 	Error error
 	// A handle for the user to keep data in the context, from the call of ReqHandler to the

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/elazarl/goproxy
 
+go 1.14
+
 require github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2

--- a/websocket.go
+++ b/websocket.go
@@ -49,7 +49,7 @@ func (proxy *ProxyHttpServer) serveWebsocketTLS(ctx *ProxyCtx, w http.ResponseWr
 func (proxy *ProxyHttpServer) serveWebsocket(ctx *ProxyCtx, w http.ResponseWriter, req *http.Request) {
 	targetURL := url.URL{Scheme: "ws", Host: req.URL.Host, Path: req.URL.Path}
 
-	targetConn, err := proxy.connectDial("tcp", targetURL.Host)
+	targetConn, err := proxy.connectDial(ctx, "tcp", targetURL.Host)
 	if err != nil {
 		ctx.Warnf("Error dialing target site: %v", err)
 		return


### PR DESCRIPTION
Allows the OnRequest handlers to hijack the ConnectDial function to dynamically set a destination, similar to the functionality available for hijacking the RoundTripper for non-CONNECT requests.
