### PR TITLE
Basic auth fixed

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -23,6 +23,8 @@ type ProxyCtx struct {
 	Session   int64
 	certStore CertStorage
 	Proxy     *ProxyHttpServer
+	// Will prevent second authentication on the already authenticated requests
+	Authenticated bool
 }
 
 type RoundTripper interface {

--- a/https.go
+++ b/https.go
@@ -198,7 +198,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 			clientTlsReader := bufio.NewReader(rawClientTls)
 			for !isEof(clientTlsReader) {
 				req, err := http.ReadRequest(clientTlsReader)
-				var ctx = &ProxyCtx{Req: req, Session: atomic.AddInt64(&proxy.sess, 1), Proxy: proxy, UserData: ctx.UserData}
+				var ctx = &ProxyCtx{Req: req, Session: atomic.AddInt64(&proxy.sess, 1), Proxy: proxy, UserData: ctx.UserData, Authenticated: ctx.Authenticated}
 				if err != nil && err != io.EOF {
 					return
 				}


### PR DESCRIPTION
**Issue:** When using AlwaysMitm ext/auth/basic.go would attempt to authenticate requests twice resulting in the 407 unauthorized message.

This fixes two outstanding issues with the basic auth behavior of this library.

1. BasicConnect handler was preventing other handlers from running (AlwaysMitm)
2. Basic was trying to authenticate connection that was already authenticated by BasicConnect

Resolves: https://github.com/elazarl/goproxy/issues/309, https://github.com/elazarl/goproxy/issues/416

Below is a simple test case to validate the behavior before/after the patch:

```
package main

import (
	"flag"
	"log"
	"net"
	"net/http"
	"regexp"

	"github.com/elazarl/goproxy"
	"github.com/elazarl/goproxy/ext/auth"
)

func handleRequest(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
	ip, _, err := net.SplitHostPort(req.RemoteAddr)
	if err != nil {
		log.Print(err)
	}

	log.Printf("[%d] %s --> %s %s", ctx.Session, ip, req.Method, req.URL)

	return req, nil
}

func main() {
	verbose := flag.Bool("v", false, "should every proxy request be logged to stdout")
	addr := flag.String("addr", ":8080", "proxy listen address")
	flag.Parse()
	username, password := "foo", "bar"
	hostmatch := "google.com|neverssl.com|apache.org"
	proxy := goproxy.NewProxyHttpServer()
	auth.ProxyBasic(proxy, "Auth", func(user, passwd string) bool {
		return user == username && password == passwd
	})
	proxy.OnRequest(goproxy.ReqHostMatches(regexp.MustCompile(hostmatch))).
		HandleConnect(goproxy.AlwaysMitm)
	proxy.OnRequest().DoFunc(handleRequest)
	proxy.Verbose = *verbose
	log.Fatal(http.ListenAndServe(*addr, proxy))
}
```