### PR TITLE
Fix method to deny connections in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,12 +136,12 @@ For example:
 
 ```go
 // This rejects the HTTPS request to *.reddit.com during HTTP CONNECT phase
-proxy.OnRequest(goproxy.ReqHostMatches(regexp.MustCompile("reddit.*:443$"))).HandleConnect(goproxy.RejectConnect)
+proxy.OnRequest(goproxy.ReqHostMatches(regexp.MustCompile("reddit.*:443$"))).HandleConnect(goproxy.AlwaysReject)
 
 // This will NOT reject the HTTPS request with URL ending with gif, due to the fact that proxy 
 // only got the URL.Hostname and URL.Port during the HTTP CONNECT phase if the scheme is HTTPS, which is
 // quiet common these days.
-proxy.OnRequest(goproxy.UrlMatches(regexp.MustCompile(`.*gif$`))).HandleConnect(goproxy.RejectConnect)
+proxy.OnRequest(goproxy.UrlMatches(regexp.MustCompile(`.*gif$`))).HandleConnect(goproxy.AlwaysReject)
 
 // The correct way to manipulate the HTTP request using URL.Path as condition is:
 proxy.OnRequest(goproxy.UrlMatches(regexp.MustCompile(`.*gif$`))).Do(YourReqHandlerFunc())


### PR DESCRIPTION
Saw that RejectConnect wasn't working, but AlwaysReject behaved as expected.