### PR TITLE
Improve an example of transparent proxy: use DialContext() instead of Dial()

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ a `ReqCondition` accepting only requests directed to "www.reddit.com".
 
 `DoFunc` will receive a function that will preprocess the request. We can change the request, or
 return a response. If the time is between 8:00am and 17:00pm, we will reject the request, and
-return a precanned text response saying "do not waste your time".
+return a pre-canned text response saying "do not waste your time".
 
 See additional examples in the examples directory.
 

--- a/examples/goproxy-transparent/README.md
+++ b/examples/goproxy-transparent/README.md
@@ -1,10 +1,10 @@
 # Transparent Proxy
 
-This transparent example in goproxy is meant to show how to transparenty proxy and hijack all http and https connections while doing a man-in-the-middle to the TLS session.  It requires that goproxy sees all the packets traversing out to the internet.  Linux iptables rules deal with changing the source/destination IPs to act transparently, but you do need to setup your network configuration so that goproxy is a mandatory stop on the outgoing route.  Primarily you can do this by placing the proxy inline.  goproxy does not have any WCCP support itself; patches welcome.
+This transparent example in goproxy is meant to show how to transparent proxy and hijack all http and https connections while doing a man-in-the-middle to the TLS session.  It requires that goproxy sees all the packets traversing out to the internet.  Linux iptables rules deal with changing the source/destination IPs to act transparently, but you do need to set up your network configuration so that goproxy is a mandatory stop on the outgoing route.  Primarily you can do this by placing the proxy inline.  goproxy does not have any WCCP support itself; patches are welcome.
 
 ## Why not explicit?
 
-Transparent proxies are more difficult to maintain and setup from a server side, but they require no configuration on the client(s) which could be in unmanaged systems or systems that don't support a proxy configuration.  See the [eavesdropper example](https://github.com/elazarl/goproxy/blob/master/examples/goproxy-eavesdropper/main.go) if you want to see an explicit proxy example.
+Transparent proxies are more difficult to maintain and set up from a server side, but they require no configuration on the client(s) which could be in unmanaged systems or systems that don't support a proxy configuration.  See the [eavesdropper example](https://github.com/elazarl/goproxy/blob/master/examples/goproxy-eavesdropper/main.go) if you want to see an explicit proxy example.
 
 ## Potential Issues
 
@@ -14,4 +14,4 @@ If you're routing table allows for it, an explicit http request to goproxy will 
 
 ## Routing Rules
 
-Example routing rules are included in [proxy.sh](https://github.com/elazarl/goproxy/blob/master/examples/goproxy-transparent/proxy.sh) but are best when setup using your distribution's configuration.
+Example routing rules are included in [proxy.sh](https://github.com/elazarl/goproxy/blob/master/examples/goproxy-transparent/proxy.sh) but are best when set up using your distribution's configuration.

--- a/examples/goproxy-transparent/transparent.go
+++ b/examples/goproxy-transparent/transparent.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -54,7 +55,8 @@ func main() {
 				client.Close()
 			}()
 			clientBuf := bufio.NewReadWriter(bufio.NewReader(client), bufio.NewWriter(client))
-			remote, err := connectDial(proxy, "tcp", req.URL.Host)
+
+			remote, err := connectDial(req.Context(), proxy, "tcp", req.URL.Host)
 			orPanic(err)
 			remoteBuf := bufio.NewReadWriter(bufio.NewReader(remote), bufio.NewWriter(remote))
 			for {
@@ -110,17 +112,17 @@ func main() {
 }
 
 // copied/converted from https.go
-func dial(proxy *goproxy.ProxyHttpServer, network, addr string) (c net.Conn, err error) {
-	if proxy.Tr.Dial != nil {
-		return proxy.Tr.Dial(network, addr)
+func dial(ctx context.Context, proxy *goproxy.ProxyHttpServer, network, addr string) (c net.Conn, err error) {
+	if proxy.Tr.DialContext != nil {
+		return proxy.Tr.DialContext(ctx, network, addr)
 	}
 	return net.Dial(network, addr)
 }
 
 // copied/converted from https.go
-func connectDial(proxy *goproxy.ProxyHttpServer, network, addr string) (c net.Conn, err error) {
+func connectDial(ctx context.Context, proxy *goproxy.ProxyHttpServer, network, addr string) (c net.Conn, err error) {
 	if proxy.ConnectDial == nil {
-		return dial(proxy, network, addr)
+		return dial(ctx, proxy, network, addr)
 	}
 	return proxy.ConnectDial(network, addr)
 }

--- a/examples/goproxy-transparent/transparent.go
+++ b/examples/goproxy-transparent/transparent.go
@@ -116,7 +116,8 @@ func dial(ctx context.Context, proxy *goproxy.ProxyHttpServer, network, addr str
 	if proxy.Tr.DialContext != nil {
 		return proxy.Tr.DialContext(ctx, network, addr)
 	}
-	return net.Dial(network, addr)
+	var d net.Dialer
+	return d.DialContext(ctx, network, addr)
 }
 
 // copied/converted from https.go


### PR DESCRIPTION
First, I gratefully appreciate your easy-to-understand sample code!
It is very useful for me to gain knowledge to support HTTPS.

I'm afraid we can improve this example by avoiding using the deprecated function `Dial()`.
Other minor text corrections are included.

