### PR TITLE
Fix the signer signing an invalid certificate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/elazarl/goproxy
+module github.com/riijj/goproxy
 
 require github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/riijj/goproxy
 
 require github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2
+
+replace github.com/elazarl/goproxy/ext => github.com/riijj/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2

--- a/https.go
+++ b/https.go
@@ -47,9 +47,25 @@ type ConnectAction struct {
 }
 
 func stripPort(s string) string {
-	ix := strings.IndexRune(s, ':')
-	if ix == -1 {
-		return s
+	var ix int
+	if strings.Contains(s,"[") && strings.Contains(s,"]") {
+		//ipv6 : for example : [2606:4700:4700::1111]:443
+
+		//strip '[' and ']'
+		s = strings.ReplaceAll(s,"[","")
+		s = strings.ReplaceAll(s,"]","")
+
+		ix = strings.LastIndexAny(s,":")
+		if ix == -1 {
+			return s
+		}
+	} else {
+		//ipv4
+		ix = strings.IndexRune(s, ':')
+		if ix == -1 {
+			return s
+		}
+
 	}
 	return s[:ix]
 }


### PR DESCRIPTION
Signer will sign invalid certificate when hostname is an IPV6 address

E.g :
      Assuming the URL is https://[2606:4700:4700::1111]:443 , the CommonName of the certificate will be: [2606 , the certificate is invalid.

this PR will fix the bug.