### PR TITLE
fix: return `Connection established` instead `OK`

### DIFF
--- a/https.go
+++ b/https.go
@@ -128,7 +128,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 			return
 		}
 		ctx.Logf("Accepting CONNECT to %s", host)
-		proxyClient.Write([]byte("HTTP/1.0 200 OK\r\n\r\n"))
+		proxyClient.Write([]byte("HTTP/1.0 200 Connection established\r\n\r\n"))
 
 		targetTCP, targetOK := targetSiteCon.(halfClosable)
 		proxyClientTCP, clientOK := proxyClient.(halfClosable)


### PR DESCRIPTION
This commit changes to return `200 Connection established` instead `200 OK`.

```
   Example of a response:

         HTTP/1.0 200 Connection established
         Proxy-agent: Netscape-Proxy/1.1

         ...data tunnelled from the server...
```

ref: https://datatracker.ietf.org/doc/html/draft-luotonen-web-proxy-tunneling-01#section-3.2