### PR TITLE
Resolves #475

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -107,6 +107,20 @@ func removeProxyHeaders(ctx *ProxyCtx, r *http.Request) {
 	r.Header.Del("Connection")
 }
 
+type flushWriter struct {
+	w io.Writer
+}
+
+func (fw flushWriter) Write(p []byte) (int, error) {
+	n, err := fw.w.Write(p)
+	if f, ok := fw.w.(http.Flusher); ok {
+		// only flush if the Writer implements the Flusher interface.
+		f.Flush()
+	}
+
+	return n, err
+}
+
 // Standard net/http function. Shouldn't be used directly, http.Serve will use it.
 func (proxy *ProxyHttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	//r.Header["X-Forwarded-For"] = w.RemoteAddr()
@@ -177,7 +191,13 @@ func (proxy *ProxyHttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		}
 		copyHeaders(w.Header(), resp.Header, proxy.KeepDestinationHeaders)
 		w.WriteHeader(resp.StatusCode)
-		nr, err := io.Copy(w, resp.Body)
+		var copyWriter io.Writer = w
+		if w.Header().Get("content-type") == "text/event-stream" {
+			// server-side events, flush the buffered data to the client.
+			copyWriter = &flushWriter{w: w}
+		}
+
+		nr, err := io.Copy(copyWriter, resp.Body)
 		if err := resp.Body.Close(); err != nil {
 			ctx.Warnf("Can't close response body %v", err)
 		}


### PR DESCRIPTION
Flush response body for server-side events to avoid events buffering by goproxy.
I validated that it works with sse.

```
$ curl -x localhost:8080 localhost:3000/events
retry: 2000
id: 1
event: data
data: {"id":1,"data":"287039","time":"8:15:06 PM","final":false}
id: 2
event: data
data: {"id":2,"data":"267182","time":"8:15:07 PM","final":false}
id: 3
event: data
data: {"id":3,"data":"657946","time":"8:15:07 PM","final":false}
```
