### PR TITLE
proxy: return 502 Bad Gateway on round-trip error

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -172,11 +172,11 @@ func (proxy *ProxyHttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 			if ctx.Error != nil {
 				errorString = "error read response " + r.URL.Host + " : " + ctx.Error.Error()
 				ctx.Logf(errorString)
-				http.Error(w, ctx.Error.Error(), 500)
+				http.Error(w, ctx.Error.Error(), 502)
 			} else {
 				errorString = "error read response " + r.URL.Host
 				ctx.Logf(errorString)
-				http.Error(w, errorString, 500)
+				http.Error(w, errorString, 502)
 			}
 			return
 		}


### PR DESCRIPTION
Currently, it's not possible to distinguish target server internal error from using a wrong server or server being down. This patch changes status code 500 to 502 in case we cannot get a response from upstream.

Below snippets from the HTTP specification:

> The HyperText Transfer Protocol (HTTP) 502 Bad Gateway
> server error response code indicates that the server, while acting as a gateway or proxy, received an invalid response from the upstream server.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502

vs.

> The HyperText Transfer Protocol (HTTP) 500 Internal Server Error
> server error response code indicates that the server encountered an unexpected condition that prevented it from fulfilling the request.
> This error response is a generic "catch-all" response. Usually, this indicates the server cannot find a better 5xx error code to response. Sometimes, server administrators log error responses like the 500 status code with more details about the request to prevent the error from happening again in the future.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500

Fixes #51