### PR TITLE
Handle https to http override in TLS MitM websocket connection

### DIFF
--- a/https.go
+++ b/https.go
@@ -242,7 +242,12 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 				if resp == nil {
 					if isWebSocketRequest(req) {
 						ctx.Logf("Request looks like websocket upgrade.")
-						proxy.serveWebsocketTLS(ctx, w, req, tlsConfig, rawClientTls)
+						if req.URL.Scheme == "http" {
+							ctx.Logf("Enforced HTTP websocket forwarding over TLS")
+							proxy.serveWebsocketHttpOverTLS(ctx, w, req, rawClientTls)
+						} else {
+							proxy.serveWebsocketTLS(ctx, w, req, tlsConfig, rawClientTls)
+						}
 						return
 					}
 					if err != nil {


### PR DESCRIPTION
In a typical MitM over CONNECT scenario there is possibility to override request schema from secure to insecure. Example: when using TLS MitM we can substitute https service using a local http server by manipulating request URL schema in OnRequest handler.
But when there is a try to open websocket connection, there is an error - always secure TLS connection is enforced regardless to request URL schema. This PR fixes that.
Resolves #506 