### PR TITLE
Added control for the nil request

### DIFF
--- a/https.go
+++ b/https.go
@@ -246,7 +246,11 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 						return
 					}
 					if err != nil {
-						ctx.Warnf("Illegal URL %s", "https://"+r.Host+req.URL.Path)
+						if req != nil {
+							ctx.Warnf("Illegal URL %s", "https://"+r.Host+req.URL.Path)
+						}else {
+							ctx.Warnf("Illegal URL %s", "https://"+r.Host)
+						}
 						return
 					}
 					removeProxyHeaders(ctx, req)


### PR DESCRIPTION
This fix is to prevent Goproxy server crashes if the request cannot be parsed in line https://github.com/elazarl/goproxy/blob/master/https.go#L234 then logged in line https://github.com/elazarl/goproxy/blob/master/https.go#L249 when proxy is in MITM mode.

Fixes #502 