### PR TITLE
Improve the https scheme matching

### DIFF
--- a/https.go
+++ b/https.go
@@ -228,7 +228,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 				req.RemoteAddr = r.RemoteAddr // since we're converting the request, need to carry over the original connecting IP as well
 				ctx.Logf("req %v", r.Host)
 
-				if !strings.HasPrefix(req.URL.String(), "https") {
+				if !strings.HasPrefix(req.URL.String(), "https://") {
 					req.URL, err = url.Parse("https://" + r.Host + req.URL.String())
 				}
 
@@ -406,7 +406,7 @@ func (proxy *ProxyHttpServer) NewConnectDialToProxyWithHandler(https_proxy strin
 			return c, nil
 		}
 	}
-	if u.Scheme == "https" || u.Scheme == "wss" {
+	if u.Scheme == "" || u.Scheme == "wss" {
 		if strings.IndexRune(u.Host, ':') == -1 {
 			u.Host += ":443"
 		}

--- a/https.go
+++ b/https.go
@@ -33,7 +33,6 @@ var (
 	MitmConnect     = &ConnectAction{Action: ConnectMitm, TLSConfig: TLSConfigFromCA(&GoproxyCa)}
 	HTTPMitmConnect = &ConnectAction{Action: ConnectHTTPMitm, TLSConfig: TLSConfigFromCA(&GoproxyCa)}
 	RejectConnect   = &ConnectAction{Action: ConnectReject, TLSConfig: TLSConfigFromCA(&GoproxyCa)}
-	httpsRegexp     = regexp.MustCompile(`^https:\/\/`)
 )
 
 // ConnectAction enables the caller to override the standard connect flow.
@@ -230,7 +229,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 				req.RemoteAddr = r.RemoteAddr // since we're converting the request, need to carry over the original connecting IP as well
 				ctx.Logf("req %v", r.Host)
 
-				if !httpsRegexp.MatchString(req.URL.String()) {
+				if !strings.HasPrefix(req.URL.String(), "https") {
 					req.URL, err = url.Parse("https://" + r.Host + req.URL.String())
 				}
 

--- a/https.go
+++ b/https.go
@@ -406,7 +406,7 @@ func (proxy *ProxyHttpServer) NewConnectDialToProxyWithHandler(https_proxy strin
 			return c, nil
 		}
 	}
-	if u.Scheme == "" || u.Scheme == "wss" {
+	if u.Scheme == "https" || u.Scheme == "wss" {
 		if strings.IndexRune(u.Host, ':') == -1 {
 			u.Host += ":443"
 		}

--- a/https.go
+++ b/https.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"


### PR DESCRIPTION
```go
httpsRegexp     = regexp.MustCompile(`^https:\/\/`)

if !httpsRegexp.MatchString(req.URL.String()) {
	req.URL, err = url.Parse("https://" + r.Host + req.URL.String())
}
```

There is some code like above. In this case, it is a little bit inappropriate to use the regular expression. This regular expression is used to determine whether the url starts with https scheme. Here, a simple `HasPrefix` is fine

I write a benchmark to show this.

```go
var httpsRegexp = regexp.MustCompile(`^https:\/\/`)

// BenchmarkMatch-12       11180230                99.44 ns/op
func BenchmarkMatch(b *testing.B) {
	b.Run("use-regex", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			httpsRegexp.MatchString("https://abc.abc.abc")
		}
	})

	b.Run("use-prefix", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			strings.HasPrefix("https://abc.abc.abc", "https")
		}
	})
}

// BenchmarkMatch
// BenchmarkMatch/use-regex
// BenchmarkMatch/use-regex-12             11810976               100.2 ns/op
// BenchmarkMatch/use-prefix
// BenchmarkMatch/use-prefix-12            347787476                3.451 ns/op
// PASS
```

It seems better.