### PR TITLE
remove duplicate call to proxy.filterResponnse on downstream errors

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -150,8 +150,6 @@ func (proxy *ProxyHttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 			resp, err = ctx.RoundTrip(r)
 			if err != nil {
 				ctx.Error = err
-				resp = proxy.filterResponse(nil, ctx)
-
 			}
 			if resp != nil {
 				ctx.Logf("Received response %v", resp.Status)


### PR DESCRIPTION
`proxy.filterResponse` is called a few lines bellow (L168). It doesn't make much sense to call `proxy.filterResponse` with the response returned from `proxy.filterResponse`. 