### PR TITLE
Avoid creating bad URLs when a mitm request has the wrong scheme

### DIFF
--- a/https.go
+++ b/https.go
@@ -233,7 +233,11 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 				ctx.Logf("req %v", r.Host)
 
 				if !httpsRegexp.MatchString(req.URL.String()) {
-					req.URL, err = url.Parse("https://" + r.Host + req.URL.String())
+					if req.URL.Scheme != "" {
+						req.URL.Scheme = "https"
+					} else {
+						req.URL, err = url.Parse("https://" + r.Host + req.URL.String())
+					}
 				}
 
 				// Bug fix which goproxy fails to provide request


### PR DESCRIPTION
If a mitm request came in like http://host/path this was getting mangled to https://hosthttp://host/path. Instead, we should just swap the scheme to https if the scheme is already defined in the url.