### PR TITLE
support for mitm ca chain

### DIFF
--- a/https.go
+++ b/https.go
@@ -453,6 +453,11 @@ func (proxy *ProxyHttpServer) NewConnectDialToProxyWithHandler(https_proxy strin
 }
 
 func TLSConfigFromCA(ca *tls.Certificate) func(host string, ctx *ProxyCtx) (*tls.Config, error) {
+	ca.Certificate = [][]byte{ca.Certificate[0]}
+	return TLSConfigFromCANative(ca)
+}
+
+func TLSConfigFromCANative(ca *tls.Certificate) func(host string, ctx *ProxyCtx) (*tls.Config, error) {
 	return func(host string, ctx *ProxyCtx) (*tls.Config, error) {
 		var err error
 		var cert *tls.Certificate

--- a/signer.go
+++ b/signer.go
@@ -96,8 +96,10 @@ func signHost(ca tls.Certificate, hosts []string) (cert *tls.Certificate, err er
 	if derBytes, err = x509.CreateCertificate(&csprng, &template, x509ca, certpriv.Public(), ca.PrivateKey); err != nil {
 		return
 	}
+	certBytes := [][]byte{derBytes}
+	certBytes = append(certBytes, ca.Certificate...)
 	return &tls.Certificate{
-		Certificate: [][]byte{derBytes, ca.Certificate[0]},
+		Certificate: certBytes,
 		PrivateKey:  certpriv,
 	}, nil
 }


### PR DESCRIPTION
This allows to return the full ca chain instead of returning only the leaf certificate.
The change is backward compatible.
Was there a security concern that I am not aware of as the reason for the initial implementation?