### PR TITLE
Ensure tls client is closed if handshake fails

### DIFF
--- a/https.go
+++ b/https.go
@@ -213,11 +213,11 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 		go func() {
 			//TODO: cache connections to the remote website
 			rawClientTls := tls.Server(proxyClient, tlsConfig)
+			defer rawClientTls.Close()
 			if err := rawClientTls.Handshake(); err != nil {
 				ctx.Warnf("Cannot handshake client %v %v", r.Host, err)
 				return
 			}
-			defer rawClientTls.Close()
 			clientTlsReader := bufio.NewReader(rawClientTls)
 			for !isEof(clientTlsReader) {
 				req, err := http.ReadRequest(clientTlsReader)


### PR DESCRIPTION
The tls client wasn't close when a handshake error occurs, this caused the proxy to keep a connection open without ever responding.