### PR TITLE
Avoid Header Canonicalization in copyHeaders by Using Direct Assignment

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -44,9 +44,8 @@ func copyHeaders(dst, src http.Header, keepDestHeaders bool) {
 		}
 	}
 	for k, vs := range src {
-		for _, v := range vs {
-			dst.Add(k, v)
-		}
+		// direct assignment to avoid canonicalization
+		dst[k] = append([]string(nil), vs...)
 	}
 }
 


### PR DESCRIPTION
This PR updates the `copyHeaders` function to avoid the canonicalization of HTTP header keys caused by the `Add` method. Instead of using `Add`, the function now directly assigns header values from `src` to `dst`, preserving their original casing. 

Let me know if further adjustments are needed!

Closes: https://github.com/elazarl/goproxy/issues/403