### PR TITLE
Add support for ED25519 CA cert key

### DIFF
--- a/counterecryptor.go
+++ b/counterecryptor.go
@@ -4,6 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
@@ -26,8 +27,12 @@ func NewCounterEncryptorRandFromKey(key interface{}, seed []byte) (r CounterEncr
 		if keyBytes, err = x509.MarshalECPrivateKey(key); err != nil {
 			return
 		}
+	case ed25519.PrivateKey:
+		if keyBytes, err = x509.MarshalPKCS8PrivateKey(key); err != nil {
+			return
+		}
 	default:
-		err = errors.New("only RSA and ECDSA keys supported")
+		err = errors.New("only RSA, ED25519 and ECDSA keys supported")
 		return
 	}
 	h := sha256.New()

--- a/signer.go
+++ b/signer.go
@@ -3,6 +3,7 @@ package goproxy
 import (
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -86,6 +87,10 @@ func signHost(ca tls.Certificate, hosts []string) (cert *tls.Certificate, err er
 		}
 	case *ecdsa.PrivateKey:
 		if certpriv, err = ecdsa.GenerateKey(elliptic.P256(), &csprng); err != nil {
+			return
+		}
+	case ed25519.PrivateKey:
+		if _, certpriv, err = ed25519.GenerateKey(&csprng); err != nil {
 			return
 		}
 	default:

--- a/signer.go
+++ b/signer.go
@@ -9,7 +9,6 @@ import (
 	"crypto/sha1"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -54,11 +53,9 @@ func signHost(ca tls.Certificate, hosts []string) (cert *tls.Certificate, err er
 		// TODO(elazar): instead of this ugly hack, just encode the certificate and hash the binary form.
 		SerialNumber: serial,
 		Issuer:       x509ca.Subject,
-		Subject: pkix.Name{
-			Organization: []string{"GoProxy untrusted MITM proxy Inc"},
-		},
-		NotBefore: start,
-		NotAfter:  end,
+		Subject:      x509ca.Subject,
+		NotBefore:    start,
+		NotAfter:     end,
 
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},


### PR DESCRIPTION
Currently `TLSConfigFromCA()` returns an error if the specified custom CA certificate uses ED25519 as the private key.
With this pull request, I add the support for it.
Compared to rsa and ecdsa, its usage among the standard library doesn't use a pointer and it has been made clear in the x509 documentation: https://pkg.go.dev/crypto/x509#MarshalPKCS8PrivateKey (it explicitly says not a pointer)