### PR TITLE
[Fix]: Adding address inside the  square brackets

### DIFF
--- a/https.go
+++ b/https.go
@@ -51,24 +51,19 @@ func stripPort(s string) string {
 	var ix int
 	if strings.Contains(s, "[") && strings.Contains(s, "]") {
 		//ipv6 : for example : [2606:4700:4700::1111]:443
-
-		//strip '[' and ']'
-		s = strings.ReplaceAll(s, "[", "")
-		s = strings.ReplaceAll(s, "]", "")
-
 		ix = strings.LastIndexAny(s, ":")
-		if ix == -1 {
+		if ix == -1 || s[ix:] == "]" {
 			return s
 		}
+		return s[:ix] 
 	} else {
 		//ipv4
 		ix = strings.IndexRune(s, ':')
 		if ix == -1 {
 			return s
 		}
-
+		return s[:ix]
 	}
-	return s[:ix]
 }
 
 func (proxy *ProxyHttpServer) dial(network, addr string) (c net.Conn, err error) {


### PR DESCRIPTION
 - ***This PR fixes the issue where IPv6 addresses with ports were not being correctly parsed due to an incorrect handling of colons.***
 - ***The fix ensures that the address is wrapped in square brackets and the port is properly separated.***

### - Fixes #562 
