### PR TITLE
Case insensitive host comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,9 @@ proxy.OnResponse(Some RespConditions).Do(YourRespHandlerFunc())
 For example:
 
 ```go
-// This rejects the HTTPS request to *.reddit.com during HTTP CONNECT phase
-proxy.OnRequest(goproxy.ReqHostMatches(regexp.MustCompile("reddit.*:443$"))).HandleConnect(goproxy.AlwaysReject)
+// This rejects the HTTPS request to *.reddit.com during HTTP CONNECT phase.
+// Reddit URL check is case-insensitive, so the block will work also if the user types something like rEdDit.com.
+proxy.OnRequest(goproxy.ReqHostMatches(regexp.MustCompile("(?i)reddit.*:443$"))).HandleConnect(goproxy.AlwaysReject)
 
 // This will NOT reject the HTTPS request with URL ending with gif, due to the fact that proxy 
 // only got the URL.Hostname and URL.Port during the HTTP CONNECT phase if the scheme is HTTPS, which is

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -189,7 +189,6 @@ func StatusCodeIs(codes ...int) RespCondition {
 // You will use the ReqProxyConds struct to register a ReqHandler, that would filter
 // the request, only if all the given ReqCondition matched.
 // Typical usage:
-//
 //	proxy.OnRequest(UrlIs("example.com/foo"),UrlMatches(regexp.MustParse(`.*\.exampl.\com\./.*`)).Do(...)
 func (proxy *ProxyHttpServer) OnRequest(conds ...ReqCondition) *ReqProxyConds {
 	return &ReqProxyConds{proxy, conds}
@@ -210,7 +209,6 @@ func (pcond *ReqProxyConds) DoFunc(f func(req *http.Request, ctx *ProxyCtx) (*ht
 // ReqProxyConds.Do will register the ReqHandler on the proxy,
 // the ReqHandler will handle the HTTP request if all the conditions
 // aggregated in the ReqProxyConds are met. Typical usage:
-//
 //	proxy.OnRequest().Do(handler) // will call handler.Handle(req,ctx) on every request to the proxy
 //	proxy.OnRequest(cond1,cond2).Do(handler)
 //	// given request to the proxy, will test if cond1.HandleReq(req,ctx) && cond2.HandleReq(req,ctx) are true
@@ -237,7 +235,6 @@ func (pcond *ReqProxyConds) Do(h ReqHandler) {
 // connection.
 // The ConnectAction struct contains possible tlsConfig that will be used for eavesdropping. If nil, the proxy
 // will use the default tls configuration.
-//
 //	proxy.OnRequest().HandleConnect(goproxy.AlwaysReject) // rejects all CONNECT requests
 func (pcond *ReqProxyConds) HandleConnect(h HttpsHandler) {
 	pcond.proxy.httpsHandlers = append(pcond.proxy.httpsHandlers,
@@ -253,7 +250,6 @@ func (pcond *ReqProxyConds) HandleConnect(h HttpsHandler) {
 
 // HandleConnectFunc is equivalent to HandleConnect,
 // for example, accepting CONNECT request if they contain a password in header
-//
 //	io.WriteString(h,password)
 //	passHash := h.Sum(nil)
 //	proxy.OnRequest().HandleConnectFunc(func(host string, ctx *ProxyCtx) (*ConnectAction, string) {
@@ -314,7 +310,6 @@ func (pcond *ProxyConds) Do(h RespHandler) {
 }
 
 // OnResponse is used when adding a response-filter to the HTTP proxy, usual pattern is
-//
 //	proxy.OnResponse(cond1,cond2).Do(handler) // handler.Handle(resp,ctx) will be used
 //				// if cond1.HandleResp(resp) && cond2.HandleResp(resp)
 func (proxy *ProxyHttpServer) OnResponse(conds ...RespCondition) *ProxyConds {
@@ -323,7 +318,6 @@ func (proxy *ProxyHttpServer) OnResponse(conds ...RespCondition) *ProxyConds {
 
 // AlwaysMitm is a HttpsHandler that always eavesdrop https connections, for example to
 // eavesdrop all https connections to www.google.com, we can use
-//
 //	proxy.OnRequest(goproxy.ReqHostIs("www.google.com")).HandleConnect(goproxy.AlwaysMitm)
 var AlwaysMitm FuncHttpsHandler = func(host string, ctx *ProxyCtx) (*ConnectAction, string) {
 	return MitmConnect, host
@@ -331,7 +325,6 @@ var AlwaysMitm FuncHttpsHandler = func(host string, ctx *ProxyCtx) (*ConnectActi
 
 // AlwaysReject is a HttpsHandler that drops any CONNECT request, for example, this code will disallow
 // connections to hosts on any other port than 443
-//
 //	proxy.OnRequest(goproxy.Not(goproxy.ReqHostMatches(regexp.MustCompile(":443$"))).
 //		HandleConnect(goproxy.AlwaysReject)
 var AlwaysReject FuncHttpsHandler = func(host string, ctx *ProxyCtx) (*ConnectAction, string) {

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -126,8 +126,9 @@ func UrlMatches(re *regexp.Regexp) ReqConditionFunc {
 
 // DstHostIs returns a ReqCondition testing wether the host in the request url is the given string
 func DstHostIs(host string) ReqConditionFunc {
+	host = strings.ToLower(host)
 	return func(req *http.Request, ctx *ProxyCtx) bool {
-		return req.URL.Host == host
+		return strings.ToLower(req.URL.Host) == host
 	}
 }
 
@@ -188,6 +189,7 @@ func StatusCodeIs(codes ...int) RespCondition {
 // You will use the ReqProxyConds struct to register a ReqHandler, that would filter
 // the request, only if all the given ReqCondition matched.
 // Typical usage:
+//
 //	proxy.OnRequest(UrlIs("example.com/foo"),UrlMatches(regexp.MustParse(`.*\.exampl.\com\./.*`)).Do(...)
 func (proxy *ProxyHttpServer) OnRequest(conds ...ReqCondition) *ReqProxyConds {
 	return &ReqProxyConds{proxy, conds}
@@ -208,6 +210,7 @@ func (pcond *ReqProxyConds) DoFunc(f func(req *http.Request, ctx *ProxyCtx) (*ht
 // ReqProxyConds.Do will register the ReqHandler on the proxy,
 // the ReqHandler will handle the HTTP request if all the conditions
 // aggregated in the ReqProxyConds are met. Typical usage:
+//
 //	proxy.OnRequest().Do(handler) // will call handler.Handle(req,ctx) on every request to the proxy
 //	proxy.OnRequest(cond1,cond2).Do(handler)
 //	// given request to the proxy, will test if cond1.HandleReq(req,ctx) && cond2.HandleReq(req,ctx) are true
@@ -234,6 +237,7 @@ func (pcond *ReqProxyConds) Do(h ReqHandler) {
 // connection.
 // The ConnectAction struct contains possible tlsConfig that will be used for eavesdropping. If nil, the proxy
 // will use the default tls configuration.
+//
 //	proxy.OnRequest().HandleConnect(goproxy.AlwaysReject) // rejects all CONNECT requests
 func (pcond *ReqProxyConds) HandleConnect(h HttpsHandler) {
 	pcond.proxy.httpsHandlers = append(pcond.proxy.httpsHandlers,
@@ -249,6 +253,7 @@ func (pcond *ReqProxyConds) HandleConnect(h HttpsHandler) {
 
 // HandleConnectFunc is equivalent to HandleConnect,
 // for example, accepting CONNECT request if they contain a password in header
+//
 //	io.WriteString(h,password)
 //	passHash := h.Sum(nil)
 //	proxy.OnRequest().HandleConnectFunc(func(host string, ctx *ProxyCtx) (*ConnectAction, string) {
@@ -309,6 +314,7 @@ func (pcond *ProxyConds) Do(h RespHandler) {
 }
 
 // OnResponse is used when adding a response-filter to the HTTP proxy, usual pattern is
+//
 //	proxy.OnResponse(cond1,cond2).Do(handler) // handler.Handle(resp,ctx) will be used
 //				// if cond1.HandleResp(resp) && cond2.HandleResp(resp)
 func (proxy *ProxyHttpServer) OnResponse(conds ...RespCondition) *ProxyConds {
@@ -317,6 +323,7 @@ func (proxy *ProxyHttpServer) OnResponse(conds ...RespCondition) *ProxyConds {
 
 // AlwaysMitm is a HttpsHandler that always eavesdrop https connections, for example to
 // eavesdrop all https connections to www.google.com, we can use
+//
 //	proxy.OnRequest(goproxy.ReqHostIs("www.google.com")).HandleConnect(goproxy.AlwaysMitm)
 var AlwaysMitm FuncHttpsHandler = func(host string, ctx *ProxyCtx) (*ConnectAction, string) {
 	return MitmConnect, host
@@ -324,6 +331,7 @@ var AlwaysMitm FuncHttpsHandler = func(host string, ctx *ProxyCtx) (*ConnectActi
 
 // AlwaysReject is a HttpsHandler that drops any CONNECT request, for example, this code will disallow
 // connections to hosts on any other port than 443
+//
 //	proxy.OnRequest(goproxy.Not(goproxy.ReqHostMatches(regexp.MustCompile(":443$"))).
 //		HandleConnect(goproxy.AlwaysReject)
 var AlwaysReject FuncHttpsHandler = func(host string, ctx *ProxyCtx) (*ConnectAction, string) {


### PR DESCRIPTION
Fixes https://github.com/elazarl/goproxy/issues/561.
Since RFC4343 states that DNS host is case-insensitive by definition, we should do a case-insensitive comparison to perform actions on certain hosts, without let the user bypassing them by simply changing the case of a character.
The DNS will resolve both the uppercase and the lowercase host text to the same IP address.
Existing integration should never rely on the case of the host, so applying this change to the whole 
Proxy server should never care about the case of the host, so directly modifying `DstHostIs` function to do a case insenstiive compare is appropriate in this case.