### PR TITLE
math/rand call refactoring

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.18
+    - name: Set up Go 1.20
       uses: actions/setup-go@v1
       with:
-        go-version: 1.18
+        go-version: 1.20
       id: go
 
     - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/elazarl/goproxy
 
-go 1.18
+go 1.20
 
 require (
-	github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2
-	golang.org/x/net v0.26.0
+	github.com/elazarl/goproxy/ext v0.0.0-20241216102027-e85c60b37433
+	golang.org/x/net v0.32.0
 )
 
-require golang.org/x/text v0.16.0 // indirect
+require golang.org/x/text v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 h1:dWB6v3RcOy03t/bUadywsbyrQwCqZeNIEX6M1OtSZOM=
-github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
+github.com/elazarl/goproxy/ext v0.0.0-20241216102027-e85c60b37433 h1:zezqs+UN/8nYMOm1PobfrT/FxliWYq5Um1DLxyHA8d0=
+github.com/elazarl/goproxy/ext v0.0.0-20241216102027-e85c60b37433/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
-golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
-golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
-golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
-golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=
+golang.org/x/net v0.32.0 h1:ZqPmj8Kzc+Y6e0+skZsuACbx+wzMgo5MQsJh9Qd6aYI=
+golang.org/x/net v0.32.0/go.mod h1:CwU0IoeOlnQQWJ6ioyFrfRuomB8GKF6KbYXZVyeXNfs=
+golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=

--- a/signer.go
+++ b/signer.go
@@ -48,10 +48,13 @@ func signHost(ca tls.Certificate, hosts []string) (cert *tls.Certificate, err er
 	start := time.Unix(time.Now().Unix()-2592000, 0) // 2592000  = 30 day
 	end := time.Unix(time.Now().Unix()+31536000, 0)  // 31536000 = 365 day
 
-	serial := big.NewInt(rand.Int63())
+	// Always generate a positive int value
+	// (Two complement is not enabled when the first bit is 0)
+	generated := rand.Uint64()
+	generated >>= 1
+
 	template := x509.Certificate{
-		// TODO(elazar): instead of this ugly hack, just encode the certificate and hash the binary form.
-		SerialNumber: serial,
+		SerialNumber: big.NewInt(int64(generated)),
 		Issuer:       x509ca.Subject,
 		Subject:      x509ca.Subject,
 		NotBefore:    start,

--- a/signer.go
+++ b/signer.go
@@ -103,8 +103,3 @@ func signHost(ca tls.Certificate, hosts []string) (cert *tls.Certificate, err er
 		PrivateKey:  certpriv,
 	}, nil
 }
-
-func init() {
-	// Avoid deterministic random numbers
-	rand.Seed(time.Now().UnixNano())
-}


### PR DESCRIPTION
Starting from Go 1.20, math/rand is automatically seeded at startup, and we don't have to manually call rand.Seed inside init().
Replace `rand.Int63()` with `rand.Uint64()` to have an easy future transition to `math/rand/v2`, since Int64 function has been removed in this library.
Uint64() >> 1 is the equivalent function to always have the 0 value as the first bit, thus having a positive serial.