### PR TITLE
Replace ioutil & magic numbers

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -2,7 +2,7 @@ package goproxy
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"regexp"
@@ -189,6 +189,7 @@ func StatusCodeIs(codes ...int) RespCondition {
 // You will use the ReqProxyConds struct to register a ReqHandler, that would filter
 // the request, only if all the given ReqCondition matched.
 // Typical usage:
+//
 //	proxy.OnRequest(UrlIs("example.com/foo"),UrlMatches(regexp.MustParse(`.*\.exampl.\com\./.*`)).Do(...)
 func (proxy *ProxyHttpServer) OnRequest(conds ...ReqCondition) *ReqProxyConds {
 	return &ReqProxyConds{proxy, conds}
@@ -209,6 +210,7 @@ func (pcond *ReqProxyConds) DoFunc(f func(req *http.Request, ctx *ProxyCtx) (*ht
 // ReqProxyConds.Do will register the ReqHandler on the proxy,
 // the ReqHandler will handle the HTTP request if all the conditions
 // aggregated in the ReqProxyConds are met. Typical usage:
+//
 //	proxy.OnRequest().Do(handler) // will call handler.Handle(req,ctx) on every request to the proxy
 //	proxy.OnRequest(cond1,cond2).Do(handler)
 //	// given request to the proxy, will test if cond1.HandleReq(req,ctx) && cond2.HandleReq(req,ctx) are true
@@ -235,6 +237,7 @@ func (pcond *ReqProxyConds) Do(h ReqHandler) {
 // connection.
 // The ConnectAction struct contains possible tlsConfig that will be used for eavesdropping. If nil, the proxy
 // will use the default tls configuration.
+//
 //	proxy.OnRequest().HandleConnect(goproxy.AlwaysReject) // rejects all CONNECT requests
 func (pcond *ReqProxyConds) HandleConnect(h HttpsHandler) {
 	pcond.proxy.httpsHandlers = append(pcond.proxy.httpsHandlers,
@@ -250,6 +253,7 @@ func (pcond *ReqProxyConds) HandleConnect(h HttpsHandler) {
 
 // HandleConnectFunc is equivalent to HandleConnect,
 // for example, accepting CONNECT request if they contain a password in header
+//
 //	io.WriteString(h,password)
 //	passHash := h.Sum(nil)
 //	proxy.OnRequest().HandleConnectFunc(func(host string, ctx *ProxyCtx) (*ConnectAction, string) {
@@ -310,6 +314,7 @@ func (pcond *ProxyConds) Do(h RespHandler) {
 }
 
 // OnResponse is used when adding a response-filter to the HTTP proxy, usual pattern is
+//
 //	proxy.OnResponse(cond1,cond2).Do(handler) // handler.Handle(resp,ctx) will be used
 //				// if cond1.HandleResp(resp) && cond2.HandleResp(resp)
 func (proxy *ProxyHttpServer) OnResponse(conds ...RespCondition) *ProxyConds {
@@ -318,6 +323,7 @@ func (proxy *ProxyHttpServer) OnResponse(conds ...RespCondition) *ProxyConds {
 
 // AlwaysMitm is a HttpsHandler that always eavesdrop https connections, for example to
 // eavesdrop all https connections to www.google.com, we can use
+//
 //	proxy.OnRequest(goproxy.ReqHostIs("www.google.com")).HandleConnect(goproxy.AlwaysMitm)
 var AlwaysMitm FuncHttpsHandler = func(host string, ctx *ProxyCtx) (*ConnectAction, string) {
 	return MitmConnect, host
@@ -325,6 +331,7 @@ var AlwaysMitm FuncHttpsHandler = func(host string, ctx *ProxyCtx) (*ConnectActi
 
 // AlwaysReject is a HttpsHandler that drops any CONNECT request, for example, this code will disallow
 // connections to hosts on any other port than 443
+//
 //	proxy.OnRequest(goproxy.Not(goproxy.ReqHostMatches(regexp.MustCompile(":443$"))).
 //		HandleConnect(goproxy.AlwaysReject)
 var AlwaysReject FuncHttpsHandler = func(host string, ctx *ProxyCtx) (*ConnectAction, string) {
@@ -336,14 +343,14 @@ var AlwaysReject FuncHttpsHandler = func(host string, ctx *ProxyCtx) (*ConnectAc
 // and will replace the body of the original response with the resulting byte array.
 func HandleBytes(f func(b []byte, ctx *ProxyCtx) []byte) RespHandler {
 	return FuncRespHandler(func(resp *http.Response, ctx *ProxyCtx) *http.Response {
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			ctx.Warnf("Cannot read response %s", err)
 			return resp
 		}
 		resp.Body.Close()
 
-		resp.Body = ioutil.NopCloser(bytes.NewBuffer(f(b, ctx)))
+		resp.Body = io.NopCloser(bytes.NewBuffer(f(b, ctx)))
 		return resp
 	})
 }

--- a/dispatcher_test.go
+++ b/dispatcher_test.go
@@ -34,7 +34,7 @@ func TestIsLocalHost(t *testing.T) {
 				addr = net.JoinHostPort(host, port)
 			}
 			t.Run(addr, func(t *testing.T) {
-				req, err := http.NewRequest("GET", "http://"+addr, http.NoBody)
+				req, err := http.NewRequest(http.MethodGet, "http://"+addr, http.NoBody)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/examples/cascadeproxy/main.go
+++ b/examples/cascadeproxy/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -82,7 +82,7 @@ func main() {
 
 	// fire a http request: client --> middle proxy --> end proxy --> internet
 	proxyUrl := "http://localhost:8081"
-	request, err := http.NewRequest("GET", "https://ip.cn", nil)
+	request, err := http.NewRequest(http.MethodGet, "https://ip.cn", nil)
 	if err != nil {
 		log.Fatalf("new request failed:%v", err)
 	}
@@ -94,7 +94,7 @@ func main() {
 
 	}
 	defer rsp.Body.Close()
-	data, _ := ioutil.ReadAll(rsp.Body)
+	data, _ := io.ReadAll(rsp.Body)
 
 	if rsp.StatusCode != http.StatusOK {
 		log.Fatalf("status %d, data %s", rsp.StatusCode, data)

--- a/examples/goproxy-jquery-version/jquery_test.go
+++ b/examples/goproxy-jquery-version/jquery_test.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 )
@@ -24,7 +25,7 @@ func equal(u, v []string) bool {
 }
 
 func readFile(fname string, t *testing.T) string {
-	b, err := ioutil.ReadFile(fname)
+	b, err := os.ReadFile(fname)
 	if err != nil {
 		t.Fatal("readFile", err)
 	}
@@ -77,7 +78,7 @@ func get(t *testing.T, server *httptest.Server, client *http.Client, url string)
 	if err != nil {
 		t.Fatal("cannot get proxy", err)
 	}
-	ioutil.ReadAll(resp.Body)
+	io.ReadAll(resp.Body)
 	resp.Body.Close()
 }
 

--- a/examples/goproxy-transparent/transparent.go
+++ b/examples/goproxy-transparent/transparent.go
@@ -96,7 +96,7 @@ func main() {
 				return
 			}
 			connectReq := &http.Request{
-				Method: "CONNECT",
+				Method: http.MethodConnect,
 				URL: &url.URL{
 					Opaque: tlsConn.Host(),
 					Host:   net.JoinHostPort(tlsConn.Host(), "443"),

--- a/examples/goproxy-yui-minify/yui.go
+++ b/examples/goproxy-yui-minify/yui.go
@@ -2,19 +2,18 @@
 // using the command line utility YUI compressor http://yui.github.io/yuicompressor/
 // Example usage:
 //
-//    ./yui -java /usr/local/bin/java -yuicompressor ~/Downloads/yuicompressor-2.4.8.jar
-//    $ curl -vx localhost:8080  http://golang.org/lib/godoc/godocs.js
-//    (function(){function g(){var u=$("#search");if(u.length===0){return}function t(){if(....
-//    $ curl http://golang.org/lib/godoc/godocs.js | head -n 3
-//    // Copyright 2012 The Go Authors. All rights reserved.
-//    // Use of this source code is governed by a BSD-style
-//    // license that can be found in the LICENSE file.
+//	./yui -java /usr/local/bin/java -yuicompressor ~/Downloads/yuicompressor-2.4.8.jar
+//	$ curl -vx localhost:8080  http://golang.org/lib/godoc/godocs.js
+//	(function(){function g(){var u=$("#search");if(u.length===0){return}function t(){if(....
+//	$ curl http://golang.org/lib/godoc/godocs.js | head -n 3
+//	// Copyright 2012 The Go Authors. All rights reserved.
+//	// Use of this source code is governed by a BSD-style
+//	// license that can be found in the LICENSE file.
 package main
 
 import (
 	"flag"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -33,7 +32,7 @@ func main() {
 	yuicompressordir := flag.String("yuicompressordir", ".", "a folder to search yuicompressor in, will be ignored if yuicompressor is set")
 	flag.Parse()
 	if *yuicompressor == "" {
-		files, err := ioutil.ReadDir(*yuicompressordir)
+		files, err := os.ReadDir(*yuicompressordir)
 		if err != nil {
 			log.Fatal("Cannot find yuicompressor jar")
 		}
@@ -76,7 +75,7 @@ func main() {
 			go func() {
 				defer stderr.Close()
 				const kb = 1024
-				msg, err := ioutil.ReadAll(&io.LimitedReader{stderr, 50 * kb})
+				msg, err := io.ReadAll(&io.LimitedReader{stderr, 50 * kb})
 				if len(msg) != 0 {
 					ctx.Logf("Error executing yuicompress: %s", string(msg))
 				}

--- a/ext/auth/basic.go
+++ b/ext/auth/basic.go
@@ -3,7 +3,7 @@ package auth
 import (
 	"bytes"
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -15,7 +15,7 @@ var unauthorizedMsg = []byte("407 Proxy Authentication Required")
 func BasicUnauthorized(req *http.Request, realm string) *http.Response {
 	// TODO(elazar): verify realm is well formed
 	return &http.Response{
-		StatusCode: 407,
+		StatusCode: http.StatusProxyAuthRequired,
 		ProtoMajor: 1,
 		ProtoMinor: 1,
 		Request:    req,
@@ -23,7 +23,7 @@ func BasicUnauthorized(req *http.Request, realm string) *http.Response {
 			"Proxy-Authenticate": []string{"Basic realm=" + realm},
 			"Proxy-Connection":   []string{"close"},
 		},
-		Body:          ioutil.NopCloser(bytes.NewBuffer(unauthorizedMsg)),
+		Body:          io.NopCloser(bytes.NewBuffer(unauthorizedMsg)),
 		ContentLength: int64(len(unauthorizedMsg)),
 	}
 }

--- a/ext/auth/basic_test.go
+++ b/ext/auth/basic_test.go
@@ -3,7 +3,6 @@ package auth_test
 import (
 	"encoding/base64"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -115,12 +114,12 @@ func TestBasicAuth(t *testing.T) {
 	if resp.Header.Get("Proxy-Authenticate") != "Basic realm=my_realm" {
 		t.Error("Expected Proxy-Authenticate header got", resp.Header.Get("Proxy-Authenticate"))
 	}
-	if resp.StatusCode != 407 {
+	if resp.StatusCode != http.StatusProxyAuthRequired {
 		t.Error("Expected status 407 Proxy Authentication Required, got", resp.Status)
 	}
 
 	// with auth
-	req, err := http.NewRequest("GET", background.URL, nil)
+	req, err := http.NewRequest(http.MethodGet, background.URL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,10 +129,10 @@ func TestBasicAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		t.Error("Expected status 200 OK, got", resp.Status)
 	}
-	msg, err := ioutil.ReadAll(resp.Body)
+	msg, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ext/html/html.go
+++ b/ext/html/html.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -37,7 +36,7 @@ var IsWebRelatedText goproxy.RespCondition = goproxy.ContentTypeIs("text/html",
 // guessing Html charset encoding from the <META> tags is not yet implemented.
 func HandleString(f func(s string, ctx *goproxy.ProxyCtx) string) goproxy.RespHandler {
 	return HandleStringReader(func(r io.Reader, ctx *goproxy.ProxyCtx) io.Reader {
-		b, err := ioutil.ReadAll(r)
+		b, err := io.ReadAll(r)
 		if err != nil {
 			ctx.Warnf("Cannot read string from resp body: %v", err)
 			return r
@@ -74,10 +73,10 @@ func HandleStringReader(f func(r io.Reader, ctx *goproxy.ProxyCtx) io.Reader) go
 				return resp
 			}
 			newr := charset.NewTranslatingReader(f(r, ctx), tr)
-			resp.Body = &readFirstCloseBoth{ioutil.NopCloser(newr), resp.Body}
+			resp.Body = &readFirstCloseBoth{io.NopCloser(newr), resp.Body}
 		} else {
 			//no translation is needed, already at utf-8
-			resp.Body = &readFirstCloseBoth{ioutil.NopCloser(f(resp.Body, ctx)), resp.Body}
+			resp.Body = &readFirstCloseBoth{io.NopCloser(f(resp.Body, ctx)), resp.Body}
 		}
 		return resp
 	})

--- a/ext/html/html_test.go
+++ b/ext/html/html_test.go
@@ -3,7 +3,7 @@ package goproxy_html_test
 import (
 	"github.com/elazarl/goproxy"
 	"github.com/elazarl/goproxy/ext/html"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -39,7 +39,7 @@ func TestCharset(t *testing.T) {
 	if err != nil {
 		t.Fatal("GET:", err)
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal("readAll:", err)
 	}

--- a/ext/image/image.go
+++ b/ext/image/image.go
@@ -8,7 +8,7 @@ import (
 	_ "image/gif"
 	"image/jpeg"
 	"image/png"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -25,7 +25,7 @@ func HandleImage(f func(img image.Image, ctx *ProxyCtx) image.Image) RespHandler
 		if !RespIsImage.HandleResp(resp, ctx) {
 			return resp
 		}
-		if resp.StatusCode != 200 {
+		if resp.StatusCode != http.StatusOK {
 			// we might get 304 - not modified response without data
 			return resp
 		}
@@ -72,7 +72,7 @@ func HandleImage(f func(img image.Image, ctx *ProxyCtx) image.Image) RespHandler
 		default:
 			panic("unhandlable type" + contentType)
 		}
-		resp.Body = ioutil.NopCloser(buf)
+		resp.Body = io.NopCloser(buf)
 		return resp
 	})
 }

--- a/https.go
+++ b/https.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -309,7 +308,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 					return
 				}
 
-				if resp.Request.Method == "HEAD" {
+				if resp.Request.Method == http.MethodHead {
 					// don't change Content-Length for HEAD request
 				} else {
 					// Since we don't know the length of resp, return chunked encoded response
@@ -328,7 +327,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 					return
 				}
 
-				if resp.Request.Method == "HEAD" {
+				if resp.Request.Method == http.MethodHead {
 					// Don't write out a response body for HEAD request
 				} else {
 					chunked := newChunkedWriter(rawClientTls)
@@ -413,7 +412,7 @@ func (proxy *ProxyHttpServer) NewConnectDialToProxyWithHandler(https_proxy strin
 		}
 		return func(network, addr string) (net.Conn, error) {
 			connectReq := &http.Request{
-				Method: "CONNECT",
+				Method: http.MethodConnect,
 				URL:    &url.URL{Opaque: addr},
 				Host:   addr,
 				Header: make(http.Header),
@@ -436,8 +435,8 @@ func (proxy *ProxyHttpServer) NewConnectDialToProxyWithHandler(https_proxy strin
 				return nil, err
 			}
 			defer resp.Body.Close()
-			if resp.StatusCode != 200 {
-				resp, err := ioutil.ReadAll(resp.Body)
+			if resp.StatusCode != http.StatusOK {
+				resp, err := io.ReadAll(resp.Body)
 				if err != nil {
 					return nil, err
 				}
@@ -458,7 +457,7 @@ func (proxy *ProxyHttpServer) NewConnectDialToProxyWithHandler(https_proxy strin
 			}
 			c = tls.Client(c, proxy.Tr.TLSClientConfig)
 			connectReq := &http.Request{
-				Method: "CONNECT",
+				Method: http.MethodConnect,
 				URL:    &url.URL{Opaque: addr},
 				Host:   addr,
 				Header: make(http.Header),
@@ -477,8 +476,8 @@ func (proxy *ProxyHttpServer) NewConnectDialToProxyWithHandler(https_proxy strin
 				return nil, err
 			}
 			defer resp.Body.Close()
-			if resp.StatusCode != 200 {
-				body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 500))
+			if resp.StatusCode != http.StatusOK {
+				body, err := io.ReadAll(io.LimitReader(resp.Body, 500))
 				if err != nil {
 					return nil, err
 				}

--- a/proxy.go
+++ b/proxy.go
@@ -126,7 +126,7 @@ func (fw flushWriter) Write(p []byte) (int, error) {
 // Standard net/http function. Shouldn't be used directly, http.Serve will use it.
 func (proxy *ProxyHttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	//r.Header["X-Forwarded-For"] = w.RemoteAddr()
-	if r.Method == "CONNECT" {
+	if r.Method == http.MethodConnect {
 		proxy.handleHttps(w, r)
 	} else {
 		ctx := &ProxyCtx{Req: r, Session: atomic.AddInt64(&proxy.sess, 1), Proxy: proxy}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"image"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -59,7 +58,7 @@ func get(url string, client *http.Client) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	txt, err := ioutil.ReadAll(resp.Body)
+	txt, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
@@ -139,7 +138,7 @@ func TestReplaceResponse(t *testing.T) {
 	proxy := goproxy.NewProxyHttpServer()
 	proxy.OnResponse().DoFunc(func(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
 		resp.StatusCode = http.StatusOK
-		resp.Body = ioutil.NopCloser(bytes.NewBufferString("chico"))
+		resp.Body = io.NopCloser(bytes.NewBufferString("chico"))
 		return resp
 	})
 
@@ -155,7 +154,7 @@ func TestReplaceReponseForUrl(t *testing.T) {
 	proxy := goproxy.NewProxyHttpServer()
 	proxy.OnResponse(goproxy.UrlIs("/koko")).DoFunc(func(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
 		resp.StatusCode = http.StatusOK
-		resp.Body = ioutil.NopCloser(bytes.NewBufferString("chico"))
+		resp.Body = io.NopCloser(bytes.NewBufferString("chico"))
 		return resp
 	})
 
@@ -180,7 +179,7 @@ func TestOneShotFileServer(t *testing.T) {
 		t.Fatal("Cannot find", file)
 	}
 	if resp, err := client.Get(fs.URL + "/" + file); err == nil {
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal("got", string(b))
 		}
@@ -223,7 +222,7 @@ func TestContentType(t *testing.T) {
 }
 
 func getImage(file string, t *testing.T) image.Image {
-	newimage, err := ioutil.ReadFile(file)
+	newimage, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatal("Cannot read file", file, err)
 	}
@@ -235,14 +234,14 @@ func getImage(file string, t *testing.T) image.Image {
 }
 
 func readAll(r io.Reader, t *testing.T) []byte {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal("Cannot read", err)
 	}
 	return b
 }
 func readFile(file string, t *testing.T) []byte {
-	b, err := ioutil.ReadFile(file)
+	b, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatal("Cannot read", err)
 	}
@@ -342,7 +341,7 @@ func TestChangeResp(t *testing.T) {
 	proxy := goproxy.NewProxyHttpServer()
 	proxy.OnResponse().DoFunc(func(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
 		resp.Body.Read([]byte{0})
-		resp.Body = ioutil.NopCloser(new(bytes.Buffer))
+		resp.Body = io.NopCloser(new(bytes.Buffer))
 		return resp
 	})
 
@@ -353,7 +352,7 @@ func TestChangeResp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ioutil.ReadAll(resp.Body)
+	io.ReadAll(resp.Body)
 	_, err = client.Get(localFile("/bobo"))
 	if err != nil {
 		t.Fatal(err)
@@ -418,7 +417,7 @@ func TestSimpleMitm(t *testing.T) {
 	creq.Write(c2)
 	c2buf := bufio.NewReader(c2)
 	resp, err := http.ReadResponse(c2buf, creq)
-	if err != nil || resp.StatusCode != 200 {
+	if err != nil || resp.StatusCode != http.StatusOK {
 		t.Fatal("Cannot CONNECT through proxy", err)
 	}
 	c2tls := tls.Client(c2, &tls.Config{InsecureSkipVerify: true})
@@ -521,7 +520,7 @@ func TestIcyResponse(t *testing.T) {
 	panicOnErr(err, "dial")
 	defer c.Close()
 	req.WriteProxy(c)
-	raw, err := ioutil.ReadAll(c)
+	raw, err := io.ReadAll(c)
 	panicOnErr(err, "readAll")
 	if string(raw) != "ICY 200 OK\r\n\r\nblablabla" {
 		t.Error("Proxy did not send the malformed response received")
@@ -543,7 +542,7 @@ func TestNoProxyHeaders(t *testing.T) {
 	s := httptest.NewServer(VerifyNoProxyHeaders{t})
 	client, l := oneShotProxy(goproxy.NewProxyHttpServer(), t)
 	defer l.Close()
-	req, err := http.NewRequest("GET", s.URL, nil)
+	req, err := http.NewRequest(http.MethodGet, s.URL, nil)
 	panicOnErr(err, "bad request")
 	req.Header.Add("Connection", "close")
 	req.Header.Add("Proxy-Connection", "close")
@@ -558,7 +557,7 @@ func TestNoProxyHeadersHttps(t *testing.T) {
 	proxy.OnRequest().HandleConnect(goproxy.AlwaysMitm)
 	client, l := oneShotProxy(proxy, t)
 	defer l.Close()
-	req, err := http.NewRequest("GET", s.URL, nil)
+	req, err := http.NewRequest(http.MethodGet, s.URL, nil)
 	panicOnErr(err, "bad request")
 	req.Header.Add("Connection", "close")
 	req.Header.Add("Proxy-Connection", "close")
@@ -604,11 +603,11 @@ func TestChunkedResponse(t *testing.T) {
 	c, err := net.Dial("tcp", "localhost:10234")
 	panicOnErr(err, "dial")
 	defer c.Close()
-	req, _ := http.NewRequest("GET", "/", nil)
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
 	req.Write(c)
 	resp, err := http.ReadResponse(bufio.NewReader(c), req)
 	panicOnErr(err, "readresp")
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	panicOnErr(err, "readall")
 	expected := "This is the data in the first chunk\r\nand this is the second one\r\nconsequence"
 	if string(b) != expected {
@@ -618,13 +617,13 @@ func TestChunkedResponse(t *testing.T) {
 	proxy := goproxy.NewProxyHttpServer()
 	proxy.OnResponse().DoFunc(func(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
 		panicOnErr(ctx.Error, "error reading output")
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		panicOnErr(err, "readall onresp")
 		if enc := resp.Header.Get("Transfer-Encoding"); enc != "" {
 			t.Fatal("Chunked response should be received as plaintext", enc)
 		}
-		resp.Body = ioutil.NopCloser(bytes.NewBufferString(strings.Replace(string(b), "e", "E", -1)))
+		resp.Body = io.NopCloser(bytes.NewBufferString(strings.Replace(string(b), "e", "E", -1)))
 		return resp
 	})
 
@@ -633,7 +632,7 @@ func TestChunkedResponse(t *testing.T) {
 
 	resp, err = client.Get("http://localhost:10234/")
 	panicOnErr(err, "client.Get")
-	b, err = ioutil.ReadAll(resp.Body)
+	b, err = io.ReadAll(resp.Body)
 	panicOnErr(err, "readall proxy")
 	if string(b) != strings.Replace(expected, "e", "E", -1) {
 		t.Error("expected", expected, "w/ e->E. Got", string(b))
@@ -644,9 +643,9 @@ func TestGoproxyThroughProxy(t *testing.T) {
 	proxy := goproxy.NewProxyHttpServer()
 	proxy2 := goproxy.NewProxyHttpServer()
 	doubleString := func(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		panicOnErr(err, "readAll resp")
-		resp.Body = ioutil.NopCloser(bytes.NewBufferString(string(b) + " " + string(b)))
+		resp.Body = io.NopCloser(bytes.NewBufferString(string(b) + " " + string(b)))
 		return resp
 	}
 	proxy.OnRequest().HandleConnect(goproxy.AlwaysMitm)
@@ -693,12 +692,12 @@ func TestGoproxyHijackConnect(t *testing.T) {
 }
 
 func readResponse(buf *bufio.Reader) string {
-	req, err := http.NewRequest("GET", srv.URL, nil)
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
 	panicOnErr(err, "NewRequest")
 	resp, err := http.ReadResponse(buf, req)
 	panicOnErr(err, "resp.Read")
 	defer resp.Body.Close()
-	txt, err := ioutil.ReadAll(resp.Body)
+	txt, err := io.ReadAll(resp.Body)
 	panicOnErr(err, "resp.Read")
 	return string(txt)
 }
@@ -888,7 +887,7 @@ func TestHttpsMitmURLRewrite(t *testing.T) {
 		defer s.Close()
 
 		fullURL := scheme + "://" + tc.Host + tc.RawPath
-		req, err := http.NewRequest("GET", fullURL, nil)
+		req, err := http.NewRequest(http.MethodGet, fullURL, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -904,7 +903,7 @@ func TestHttpsMitmURLRewrite(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		defer resp.Body.Close()
 		if err != nil {
 			t.Fatal(err)
@@ -949,7 +948,7 @@ func TestSimpleHttpRequest(t *testing.T) {
 	resp, err := client.Get("http://example.com")
 	if err != nil {
 		t.Error("Error requesting http site", err)
-	} else if resp.StatusCode != 200 {
+	} else if resp.StatusCode != http.StatusOK {
 		t.Error("Non-OK status requesting http site", err)
 	}
 	resp, _ = client.Get("http://example.invalid")
@@ -982,7 +981,7 @@ func TestResponseContentLength(t *testing.T) {
 	proxy.OnResponse().DoFunc(func(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
 		buf := &bytes.Buffer{}
 		buf.Write([]byte("change"))
-		resp.Body = ioutil.NopCloser(buf)
+		resp.Body = io.NopCloser(buf)
 		return resp
 	})
 	proxySrv := httptest.NewServer(proxy)
@@ -997,7 +996,7 @@ func TestResponseContentLength(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	resp, _ := http.DefaultClient.Do(req)
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 
 	if int64(len(body)) != resp.ContentLength {

--- a/regretable/regretreader.go
+++ b/regretable/regretreader.go
@@ -6,7 +6,8 @@ import (
 
 // A RegretableReader will allow you to read from a reader, and then
 // to "regret" reading it, and push back everything you've read.
-// For example,
+// For example:
+//
 //	rb := NewRegretableReader(bytes.NewBuffer([]byte{1,2,3}))
 //	var b = make([]byte,1)
 //	rb.Read(b) // b[0] = 1
@@ -52,6 +53,7 @@ func (rb *RegretableReader) Regret() {
 }
 
 // Will "forget" everything read so far.
+//
 //	rb := NewRegretableReader(bytes.NewBuffer([]byte{1,2,3}))
 //	var b = make([]byte,1)
 //	rb.Read(b) // b[0] = 1

--- a/regretable/regretreader_test.go
+++ b/regretable/regretreader_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	. "github.com/elazarl/goproxy/regretable"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 )
@@ -19,7 +18,7 @@ func TestRegretableReader(t *testing.T) {
 	mb.Read(fivebytes)
 	mb.Regret()
 
-	s, _ := ioutil.ReadAll(mb)
+	s, _ := io.ReadAll(mb)
 	if string(s) != word {
 		t.Errorf("Uncommitted read is gone, [%d,%d] actual '%v' expected '%v'\n", len(s), len(word), string(s), word)
 	}
@@ -35,7 +34,7 @@ func TestRegretableEmptyRead(t *testing.T) {
 	mb.Read(zero)
 	mb.Regret()
 
-	s, err := ioutil.ReadAll(mb)
+	s, err := io.ReadAll(mb)
 	if string(s) != word {
 		t.Error("Uncommitted read is gone, actual:", string(s), "expected:", word, "err:", err)
 	}
@@ -55,7 +54,7 @@ func TestRegretableAlsoEmptyRead(t *testing.T) {
 	mb.Read(five)
 	mb.Regret()
 
-	s, _ := ioutil.ReadAll(mb)
+	s, _ := io.ReadAll(mb)
 	if string(s) != word {
 		t.Error("Uncommitted read is gone", string(s), "expected", word)
 	}
@@ -71,7 +70,7 @@ func TestRegretableRegretBeforeRead(t *testing.T) {
 	mb.Regret()
 	mb.Read(five)
 
-	s, err := ioutil.ReadAll(mb)
+	s, err := io.ReadAll(mb)
 	if string(s) != "678" {
 		t.Error("Uncommitted read is gone", string(s), len(string(s)), "expected", "678", len("678"), "err:", err)
 	}
@@ -87,7 +86,7 @@ func TestRegretableFullRead(t *testing.T) {
 	mb.Read(twenty)
 	mb.Regret()
 
-	s, _ := ioutil.ReadAll(mb)
+	s, _ := io.ReadAll(mb)
 	if string(s) != word {
 		t.Error("Uncommitted read is gone", string(s), len(string(s)), "expected", word, len(word))
 	}
@@ -100,7 +99,7 @@ func assertEqual(t *testing.T, expected, actual string) {
 }
 
 func assertReadAll(t *testing.T, r io.Reader) string {
-	s, err := ioutil.ReadAll(r)
+	s, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal("error when reading", err)
 	}
@@ -148,7 +147,7 @@ func TestRegretableCloserSizeRegrets(t *testing.T) {
 	}()
 	buf := new(bytes.Buffer)
 	buf.WriteString("123456")
-	mb := NewRegretableReaderCloserSize(ioutil.NopCloser(buf), 3)
+	mb := NewRegretableReaderCloserSize(io.NopCloser(buf), 3)
 	mb.Read(make([]byte, 4))
 	mb.Regret()
 }

--- a/responses.go
+++ b/responses.go
@@ -2,7 +2,7 @@ package goproxy
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -24,7 +24,7 @@ func NewResponse(r *http.Request, contentType string, status int, body string) *
 	resp.Status = http.StatusText(status)
 	buf := bytes.NewBufferString(body)
 	resp.ContentLength = int64(buf.Len())
-	resp.Body = ioutil.NopCloser(buf)
+	resp.Body = io.NopCloser(buf)
 	return resp
 }
 

--- a/signer_test.go
+++ b/signer_test.go
@@ -3,7 +3,7 @@ package goproxy
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -70,12 +70,12 @@ func testSignerTls(t *testing.T, ca tls.Certificate) {
 		TLSClientConfig: &tls.Config{RootCAs: certpool},
 	}
 	asLocalhost := strings.Replace(server.URL, "127.0.0.1", "localhost", -1)
-	req, err := http.NewRequest("GET", asLocalhost, nil)
+	req, err := http.NewRequest(http.MethodGet, asLocalhost, nil)
 	orFatal("NewRequest", err, t)
 	resp, err := tr.RoundTrip(req)
 	orFatal("RoundTrip", err, t)
-	txt, err := ioutil.ReadAll(resp.Body)
-	orFatal("ioutil.ReadAll", err, t)
+	txt, err := io.ReadAll(resp.Body)
+	orFatal("io.ReadAll", err, t)
 	if string(txt) != expected {
 		t.Errorf("Expected '%s' got '%s'", expected, string(txt))
 	}


### PR DESCRIPTION
- Replace deprecated package (ioutil) with io and os functions
- Reformat spacing of comments inside files
- Replace constant method names (e.g. "GET") with http library constants (e.g. http.MethodGet)
- Replace constant status codes (e.g. 200) with http library constants (e.g. http.StatusOK)