### PR TITLE
Prevent Request headers canonicalization

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,6 @@ linters:
     - containedctx
     - decorder
     - dogsled
-    - dupl
     - durationcheck
     - errchkjson
     - errname
@@ -80,6 +79,7 @@ linters:
     - copyloopvar
     - cyclop
     - depguard
+    - dupl
     - dupword
     - err113
     - exhaustruct

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ proxy is `localhost:8080`, which is the default one in our example.
 - You can specify a `MITM certificates cache`, to reuse them later for other requests to the same host, thus saving CPU. Not enabled by default, but you should use it in production!
 - Redirect normal HTTP traffic to a `custom handler`, when the target is a `relative path` (e.g. `/ping`)
 - You can choose the logger to use, by implementing the `Logger` interface
+- You can `disable` the HTTP request headers `canonicalization`, by setting `PreventCanonicalization` to true
 
 ## Proxy modes
 1. Regular HTTP proxy

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,14 @@ module github.com/elazarl/goproxy
 
 go 1.20
 
-require golang.org/x/net v0.33.0
+require (
+	github.com/stretchr/testify v1.10.0
+	golang.org/x/net v0.33.0
+)
 
-require golang.org/x/text v0.21.0 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/text v0.21.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
 golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
 golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/https.go
+++ b/https.go
@@ -222,7 +222,10 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 					httpError(proxyClient, ctx, err)
 					return
 				}
-				resp, err = http.ReadResponse(remote, req)
+				resp, err = func() (*http.Response, error) {
+					defer req.Body.Close()
+					return http.ReadResponse(remote, req)
+				}()
 				if err != nil {
 					httpError(proxyClient, ctx, err)
 					return

--- a/internal/http1parser/header.go
+++ b/internal/http1parser/header.go
@@ -1,165 +1,43 @@
 package http1parser
 
-import "errors"
-
-var (
-	ErrBadProto    = errors.New("bad protocol")
-	ErrMissingData = errors.New("missing data")
+import (
+	"errors"
+	"net/textproto"
+	"strings"
 )
 
-const (
-	_eNextHeader int = iota
-	_eNextHeaderN
-	_eHeader
-	_eHeaderValueSpace
-	_eHeaderValue
-	_eHeaderValueN
-	_eMLHeaderStart
-	_eMLHeaderValue
-)
+var ErrBadProto = errors.New("bad protocol")
 
 // Http1ExtractHeaders is an HTTP/1.0 and HTTP/1.1 header-only parser,
 // to extract the original header names for the received request.
-// Fully inspired by https://github.com/evanphx/wildcat
-func Http1ExtractHeaders(input []byte) ([]string, error) {
-	total := len(input)
-	var path, version, headers int
+// Fully inspired by readMIMEHeader() in
+// https://github.com/golang/go/blob/master/src/net/textproto/reader.go
+func Http1ExtractHeaders(r *textproto.Reader) ([]string, error) {
+	// Discard first line, it doesn't contain useful information, and it has
+	// already been validated in http.ReadRequest()
+	if _, err := r.ReadLine(); err != nil {
+		return nil, err
+	}
+
+	// The first line cannot start with a leading space.
+	if buf, err := r.R.Peek(1); err == nil && (buf[0] == ' ' || buf[0] == '\t') {
+		return nil, ErrBadProto
+	}
+
 	var headerNames []string
-
-	// First line: METHOD PATH VERSION
-	var methodOk bool
-	for i := 0; i < total; i++ {
-		switch input[i] {
-		case ' ', '\t':
-			methodOk = true
-			path = i + 1
+	for {
+		kv, err := r.ReadContinuedLine()
+		if len(kv) == 0 {
+			// We have finished to parse the headers if we receive empty
+			// data without an error
+			return headerNames, err
 		}
-		if methodOk {
-			break
+
+		// Key ends at first colon.
+		k, _, ok := strings.Cut(kv, ":")
+		if !ok {
+			return nil, ErrBadProto
 		}
+		headerNames = append(headerNames, k)
 	}
-
-	if !methodOk {
-		return nil, ErrMissingData
-	}
-
-	var pathOk bool
-	for i := path; i < total; i++ {
-		switch input[i] {
-		case ' ', '\t':
-			pathOk = true
-			version = i + 1
-		}
-		if pathOk {
-			break
-		}
-	}
-
-	if !pathOk {
-		return nil, ErrMissingData
-	}
-
-	var versionOk bool
-	var readN bool
-	for i := version; i < total; i++ {
-		c := input[i]
-
-		switch readN {
-		case false:
-			switch c {
-			case '\r':
-				readN = true
-			case '\n':
-				headers = i + 1
-				versionOk = true
-			}
-		case true:
-			if c != '\n' {
-				return nil, ErrBadProto
-			}
-			headers = i + 1
-			versionOk = true
-		}
-		if versionOk {
-			break
-		}
-	}
-
-	if !versionOk {
-		return nil, ErrMissingData
-	}
-
-	// Header parsing
-	state := _eNextHeader
-	start := headers
-
-	for i := headers; i < total; i++ {
-		switch state {
-		case _eNextHeader:
-			switch input[i] {
-			case '\r':
-				state = _eNextHeaderN
-			case '\n':
-				return headerNames, nil
-			case ' ', '\t':
-				state = _eMLHeaderStart
-			default:
-				start = i
-				state = _eHeader
-			}
-		case _eNextHeaderN:
-			if input[i] != '\n' {
-				return nil, ErrBadProto
-			}
-
-			return headerNames, nil
-		case _eHeader:
-			if input[i] == ':' {
-				headerName := input[start:i]
-				headerNames = append(headerNames, string(headerName))
-				state = _eHeaderValueSpace
-			}
-		case _eHeaderValueSpace:
-			switch input[i] {
-			case ' ', '\t':
-				continue
-			}
-
-			start = i
-			state = _eHeaderValue
-		case _eHeaderValue:
-			switch input[i] {
-			case '\r':
-				state = _eHeaderValueN
-			case '\n':
-				state = _eNextHeader
-			default:
-				continue
-			}
-		case _eHeaderValueN:
-			if input[i] != '\n' {
-				return nil, ErrBadProto
-			}
-			state = _eNextHeader
-		case _eMLHeaderStart:
-			switch input[i] {
-			case ' ', '\t':
-				continue
-			}
-
-			start = i
-			state = _eMLHeaderValue
-		case _eMLHeaderValue:
-			switch input[i] {
-			case '\r':
-				state = _eHeaderValueN
-			case '\n':
-				state = _eNextHeader
-			default:
-				continue
-			}
-		}
-	}
-
-	return nil, ErrMissingData
 }

--- a/internal/http1parser/header.go
+++ b/internal/http1parser/header.go
@@ -1,0 +1,165 @@
+package http1parser
+
+import "errors"
+
+var (
+	ErrBadProto    = errors.New("bad protocol")
+	ErrMissingData = errors.New("missing data")
+)
+
+const (
+	_eNextHeader int = iota
+	_eNextHeaderN
+	_eHeader
+	_eHeaderValueSpace
+	_eHeaderValue
+	_eHeaderValueN
+	_eMLHeaderStart
+	_eMLHeaderValue
+)
+
+// Http1ExtractHeaders is an HTTP/1.0 and HTTP/1.1 header-only parser,
+// to extract the original header names for the received request.
+// Fully inspired by https://github.com/evanphx/wildcat
+func Http1ExtractHeaders(input []byte) ([]string, error) {
+	total := len(input)
+	var path, version, headers int
+	var headerNames []string
+
+	// First line: METHOD PATH VERSION
+	var methodOk bool
+	for i := 0; i < total; i++ {
+		switch input[i] {
+		case ' ', '\t':
+			methodOk = true
+			path = i + 1
+		}
+		if methodOk {
+			break
+		}
+	}
+
+	if !methodOk {
+		return nil, ErrMissingData
+	}
+
+	var pathOk bool
+	for i := path; i < total; i++ {
+		switch input[i] {
+		case ' ', '\t':
+			pathOk = true
+			version = i + 1
+		}
+		if pathOk {
+			break
+		}
+	}
+
+	if !pathOk {
+		return nil, ErrMissingData
+	}
+
+	var versionOk bool
+	var readN bool
+	for i := version; i < total; i++ {
+		c := input[i]
+
+		switch readN {
+		case false:
+			switch c {
+			case '\r':
+				readN = true
+			case '\n':
+				headers = i + 1
+				versionOk = true
+			}
+		case true:
+			if c != '\n' {
+				return nil, ErrBadProto
+			}
+			headers = i + 1
+			versionOk = true
+		}
+		if versionOk {
+			break
+		}
+	}
+
+	if !versionOk {
+		return nil, ErrMissingData
+	}
+
+	// Header parsing
+	state := _eNextHeader
+	start := headers
+
+	for i := headers; i < total; i++ {
+		switch state {
+		case _eNextHeader:
+			switch input[i] {
+			case '\r':
+				state = _eNextHeaderN
+			case '\n':
+				return headerNames, nil
+			case ' ', '\t':
+				state = _eMLHeaderStart
+			default:
+				start = i
+				state = _eHeader
+			}
+		case _eNextHeaderN:
+			if input[i] != '\n' {
+				return nil, ErrBadProto
+			}
+
+			return headerNames, nil
+		case _eHeader:
+			if input[i] == ':' {
+				headerName := input[start:i]
+				headerNames = append(headerNames, string(headerName))
+				state = _eHeaderValueSpace
+			}
+		case _eHeaderValueSpace:
+			switch input[i] {
+			case ' ', '\t':
+				continue
+			}
+
+			start = i
+			state = _eHeaderValue
+		case _eHeaderValue:
+			switch input[i] {
+			case '\r':
+				state = _eHeaderValueN
+			case '\n':
+				state = _eNextHeader
+			default:
+				continue
+			}
+		case _eHeaderValueN:
+			if input[i] != '\n' {
+				return nil, ErrBadProto
+			}
+			state = _eNextHeader
+		case _eMLHeaderStart:
+			switch input[i] {
+			case ' ', '\t':
+				continue
+			}
+
+			start = i
+			state = _eMLHeaderValue
+		case _eMLHeaderValue:
+			switch input[i] {
+			case '\r':
+				state = _eHeaderValueN
+			case '\n':
+				state = _eNextHeader
+			default:
+				continue
+			}
+		}
+	}
+
+	return nil, ErrMissingData
+}

--- a/internal/http1parser/header_test.go
+++ b/internal/http1parser/header_test.go
@@ -1,0 +1,40 @@
+package http1parser_test
+
+import (
+	"testing"
+
+	"github.com/elazarl/goproxy/internal/http1parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHttp1ExtractHeaders_Empty(t *testing.T) {
+	http1Data := "POST /index.html HTTP/1.1\r\n" +
+		"\r\n"
+	headers, err := http1parser.Http1ExtractHeaders([]byte(http1Data))
+	require.NoError(t, err)
+	assert.Len(t, headers, 0)
+}
+
+func TestHttp1ExtractHeaders(t *testing.T) {
+	http1Data := "POST /index.html HTTP/1.1\r\n" +
+		"Host: www.test.com\r\n" +
+		"Accept: */*\r\n" +
+		"Content-Length: 17\r\n" +
+		"lowercase: 3z\r\n" +
+		"\r\n" +
+		`{"hello":"world"}`
+
+	headers, err := http1parser.Http1ExtractHeaders([]byte(http1Data))
+	require.NoError(t, err)
+	assert.Len(t, headers, 4)
+	assert.Contains(t, headers, "Content-Length")
+	assert.Contains(t, headers, "lowercase")
+}
+
+func TestHttp1ExtractHeaders_InvalidData(t *testing.T) {
+	http1Data := "POST /index.html HTTP/1.1\r\n" +
+		`{"hello":"world"}`
+	_, err := http1parser.Http1ExtractHeaders([]byte(http1Data))
+	require.Error(t, err)
+}

--- a/internal/http1parser/header_test.go
+++ b/internal/http1parser/header_test.go
@@ -13,7 +13,7 @@ func TestHttp1ExtractHeaders_Empty(t *testing.T) {
 		"\r\n"
 	headers, err := http1parser.Http1ExtractHeaders([]byte(http1Data))
 	require.NoError(t, err)
-	assert.Len(t, headers, 0)
+	assert.Empty(t, headers)
 }
 
 func TestHttp1ExtractHeaders(t *testing.T) {

--- a/internal/http1parser/header_test.go
+++ b/internal/http1parser/header_test.go
@@ -1,6 +1,9 @@
 package http1parser_test
 
 import (
+	"bufio"
+	"bytes"
+	"net/textproto"
 	"testing"
 
 	"github.com/elazarl/goproxy/internal/http1parser"
@@ -11,7 +14,9 @@ import (
 func TestHttp1ExtractHeaders_Empty(t *testing.T) {
 	http1Data := "POST /index.html HTTP/1.1\r\n" +
 		"\r\n"
-	headers, err := http1parser.Http1ExtractHeaders([]byte(http1Data))
+
+	textParser := textproto.NewReader(bufio.NewReader(bytes.NewReader([]byte(http1Data))))
+	headers, err := http1parser.Http1ExtractHeaders(textParser)
 	require.NoError(t, err)
 	assert.Empty(t, headers)
 }
@@ -19,13 +24,14 @@ func TestHttp1ExtractHeaders_Empty(t *testing.T) {
 func TestHttp1ExtractHeaders(t *testing.T) {
 	http1Data := "POST /index.html HTTP/1.1\r\n" +
 		"Host: www.test.com\r\n" +
-		"Accept: */*\r\n" +
+		"Accept: */ /*\r\n" +
 		"Content-Length: 17\r\n" +
 		"lowercase: 3z\r\n" +
 		"\r\n" +
 		`{"hello":"world"}`
 
-	headers, err := http1parser.Http1ExtractHeaders([]byte(http1Data))
+	textParser := textproto.NewReader(bufio.NewReader(bytes.NewReader([]byte(http1Data))))
+	headers, err := http1parser.Http1ExtractHeaders(textParser)
 	require.NoError(t, err)
 	assert.Len(t, headers, 4)
 	assert.Contains(t, headers, "Content-Length")
@@ -35,6 +41,8 @@ func TestHttp1ExtractHeaders(t *testing.T) {
 func TestHttp1ExtractHeaders_InvalidData(t *testing.T) {
 	http1Data := "POST /index.html HTTP/1.1\r\n" +
 		`{"hello":"world"}`
-	_, err := http1parser.Http1ExtractHeaders([]byte(http1Data))
+
+	textParser := textproto.NewReader(bufio.NewReader(bytes.NewReader([]byte(http1Data))))
+	_, err := http1parser.Http1ExtractHeaders(textParser)
 	require.Error(t, err)
 }

--- a/internal/http1parser/request.go
+++ b/internal/http1parser/request.go
@@ -1,0 +1,68 @@
+package http1parser
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net/http"
+	"net/textproto"
+)
+
+func ReadRequest(preventCanonicalization bool, r *bufio.Reader, cloned *bytes.Buffer) (*http.Request, error) {
+	if !preventCanonicalization {
+		// Just call the HTTP library function if the preventCanonicalization
+		// configuration is disabled
+		req, err := http.ReadRequest(r)
+		if err != nil {
+			return nil, err
+		}
+
+		// Discard the raw bytes related to the current request, we don't care
+		// about them since we don't have to do anything
+		_ = getRequestData(req, r, cloned)
+		return req, nil
+	}
+
+	req, err := http.ReadRequest(r)
+	if err != nil {
+		return nil, err
+	}
+
+	httpData := getRequestData(req, r, cloned)
+	headers, _ := Http1ExtractHeaders(httpData)
+	for _, headerName := range headers {
+		canonicalizedName := textproto.CanonicalMIMEHeaderKey(headerName)
+		if canonicalizedName == headerName {
+			continue
+		}
+
+		// Rewrite header keys to the non-canonical parsed value
+		values, ok := req.Header[canonicalizedName]
+		if ok {
+			req.Header.Del(canonicalizedName)
+			req.Header[headerName] = values
+		}
+	}
+
+	return req, nil
+}
+
+func getRequestData(req *http.Request, r *bufio.Reader, cloned *bytes.Buffer) []byte {
+	// We need to read the whole request body here because,
+	// however, body data will remain unread inside the *bufio.Reader,
+	// after the call to http.ReadRequest() and, without the read here,
+	// we would consider them as part of the next request.
+	// Without the body read, we wouldn't be able to know the total
+	// length of data related to the current request.
+	bodyData, _ := io.ReadAll(req.Body)
+	_ = req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewReader(bodyData))
+
+	// "Cloned" buffer uses the raw connection as the data source.
+	// However, the *bufio.Reader can read also bytes of another unrelated
+	// request on the same connection, since it's buffered, so we have to
+	// ignore them before passing the data to our headers parser.
+	// Data related to the next request will remain inside the buffer for
+	// later usage.
+	return cloned.Next(cloned.Len() - r.Buffered())
+}

--- a/internal/http1parser/request_test.go
+++ b/internal/http1parser/request_test.go
@@ -40,10 +40,6 @@ func TestCanonicalRequest(t *testing.T) {
 	assert.NotEmpty(t, req.Header)
 	assert.NotContains(t, req.Header, "lowercase")
 	assert.Contains(t, req.Header, "Lowercase")
-
-	body, err := io.ReadAll(req.Body)
-	require.NoError(t, err)
-	assert.Len(t, body, 17)
 	require.NoError(t, req.Body.Close())
 
 	// 2nd request

--- a/internal/http1parser/request_test.go
+++ b/internal/http1parser/request_test.go
@@ -1,8 +1,13 @@
 package http1parser_test
 
 import (
+	"bufio"
 	"bytes"
+	"fmt"
 	"io"
+	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/elazarl/goproxy/internal/http1parser"
@@ -79,4 +84,121 @@ func TestMultipleNonCanonicalRequests(t *testing.T) {
 	assert.NotEmpty(t, req.Header)
 
 	assert.True(t, parser.IsEOF())
+}
+
+// reqTest is inspired by https://github.com/golang/go/blob/master/src/net/http/readrequest_test.go
+type reqTest struct {
+	Raw     string
+	Req     *http.Request
+	Body    string
+	Trailer http.Header
+	Error   string
+}
+
+var (
+	noError   = ""
+	noBodyStr = ""
+	noTrailer http.Header
+)
+
+var reqTests = []reqTest{
+	// Baseline test; All Request fields included for template use
+	{
+		"GET http://www.techcrunch.com/ HTTP/1.1\r\n" +
+			"Host: www.techcrunch.com\r\n" +
+			"user-agent: Fake\r\n" +
+			"Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n" +
+			"Accept-Language: en-us,en;q=0.5\r\n" +
+			"Accept-Encoding: gzip,deflate\r\n" +
+			"Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.7\r\n" +
+			"Keep-Alive: 300\r\n" +
+			"Content-Length: 7\r\n" +
+			"Proxy-Connection: keep-alive\r\n\r\n" +
+			"abcdef\n???",
+		&http.Request{
+			Method: http.MethodGet,
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "www.techcrunch.com",
+				Path:   "/",
+			},
+			Proto:      "HTTP/1.1",
+			ProtoMajor: 1,
+			ProtoMinor: 1,
+			Header: http.Header{
+				"Accept":           {"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"},
+				"Accept-Language":  {"en-us,en;q=0.5"},
+				"Accept-Encoding":  {"gzip,deflate"},
+				"Accept-Charset":   {"ISO-8859-1,utf-8;q=0.7,*;q=0.7"},
+				"Keep-Alive":       {"300"},
+				"Proxy-Connection": {"keep-alive"},
+				"Content-Length":   {"7"},
+				"user-agent":       {"Fake"},
+			},
+			Close:         false,
+			ContentLength: 7,
+			Host:          "www.techcrunch.com",
+			RequestURI:    "http://www.techcrunch.com/",
+		},
+		"abcdef\n",
+		noTrailer,
+		noError,
+	},
+
+	// GET request with no body (the normal case)
+	{
+		"GET / HTTP/1.1\r\n" +
+			"Host: foo.com\r\n\r\n",
+		&http.Request{
+			Method: http.MethodGet,
+			URL: &url.URL{
+				Path: "/",
+			},
+			Proto:         "HTTP/1.1",
+			ProtoMajor:    1,
+			ProtoMinor:    1,
+			Header:        http.Header{},
+			Close:         false,
+			ContentLength: 0,
+			Host:          "foo.com",
+			RequestURI:    "/",
+		},
+		noBodyStr,
+		noTrailer,
+		noError,
+	},
+}
+
+func TestReadRequest(t *testing.T) {
+	for i := range reqTests {
+		tt := &reqTests[i]
+
+		testName := fmt.Sprintf("Test %d (%q)", i, tt.Raw)
+		t.Run(testName, func(t *testing.T) {
+			r := bufio.NewReader(strings.NewReader(tt.Raw))
+			parser := http1parser.NewRequestReader(true, r)
+			req, err := parser.ReadRequest()
+			if err != nil && err.Error() == tt.Error {
+				// Test finished, we expected an error
+				return
+			}
+			require.NoError(t, err)
+
+			// Check request equality (excluding body)
+			rbody := req.Body
+			req.Body = nil
+			assert.Equal(t, tt.Req, req)
+
+			// Check if the two bodies match
+			var bodyString string
+			if rbody != nil {
+				data, err := io.ReadAll(rbody)
+				require.NoError(t, err)
+				bodyString = string(data)
+				_ = rbody.Close()
+			}
+			assert.Equal(t, tt.Body, bodyString)
+			assert.Equal(t, tt.Trailer, req.Trailer)
+		})
+	}
 }

--- a/internal/http1parser/request_test.go
+++ b/internal/http1parser/request_test.go
@@ -1,0 +1,116 @@
+package http1parser_test
+
+import (
+	"bufio"
+	"bytes"
+	"github.com/elazarl/goproxy/internal/http1parser"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"testing"
+)
+
+func TestCanonicalRequest(t *testing.T) {
+	data := "POST /index.html HTTP/1.1\r\n" +
+		"Host: www.test.com\r\n" +
+		"Accept: */*\r\n" +
+		"Content-Length: 17\r\n" +
+		"lowercase: 3z\r\n" +
+		"\r\n" +
+		`{"hello":"world"}`
+
+	data2 := "GET /index.html HTTP/1.1\r\n" +
+		"Host: www.test.com\r\n" +
+		"Accept: */*\r\n" +
+		"lowercase: 3z\r\n" +
+		"\r\n"
+
+	// Here we are simulating two requests on the same connection
+	http1Data := bytes.NewReader(append([]byte(data), data2...))
+
+	var cloned bytes.Buffer
+	r := bufio.NewReader(io.TeeReader(http1Data, &cloned))
+
+	// 1st request
+	req, err := http1parser.ReadRequest(false, r, &cloned)
+	require.NoError(t, err)
+	assert.NotEmpty(t, req.Header)
+	assert.NotContains(t, req.Header, "lowercase")
+	assert.Contains(t, req.Header, "Lowercase")
+
+	body, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	assert.Len(t, body, 17)
+	require.NoError(t, req.Body.Close())
+
+	// 2nd request
+	req, err = http1parser.ReadRequest(false, r, &cloned)
+	require.NoError(t, err)
+	assert.NotEmpty(t, req.Header)
+
+	// Make sure that the buffers are empty after all requests have been processed
+	assert.Equal(t, 0, r.Buffered())
+	assert.Equal(t, 0, cloned.Len())
+}
+
+func TestNonCanonicalRequest(t *testing.T) {
+	http1Data := bytes.NewReader([]byte("POST /index.html HTTP/1.1\r\n" +
+		"Host: www.test.com\r\n" +
+		"Accept: */*\r\n" +
+		"Content-Length: 17\r\n" +
+		"lowercase: 3z\r\n" +
+		"\r\n" +
+		`{"hello":"world"}`),
+	)
+
+	var cloned bytes.Buffer
+	r := bufio.NewReader(io.TeeReader(http1Data, &cloned))
+
+	req, err := http1parser.ReadRequest(true, r, &cloned)
+	require.NoError(t, err)
+	assert.NotEmpty(t, req.Header)
+	assert.Contains(t, req.Header, "lowercase")
+	assert.NotContains(t, req.Header, "Lowercase")
+}
+
+func TestMultipleNonCanonicalRequests(t *testing.T) {
+	data := "POST /index.html HTTP/1.1\r\n" +
+		"Host: www.test.com\r\n" +
+		"Accept: */*\r\n" +
+		"Content-Length: 17\r\n" +
+		"lowercase: 3z\r\n" +
+		"\r\n" +
+		`{"hello":"world"}`
+
+	data2 := "GET /index.html HTTP/1.1\r\n" +
+		"Host: www.test.com\r\n" +
+		"Accept: */*\r\n" +
+		"lowercase: 3z\r\n" +
+		"\r\n"
+
+	// Here we are simulating two requests on the same connection
+	http1Data := bytes.NewReader(append([]byte(data), data2...))
+
+	var cloned bytes.Buffer
+	r := bufio.NewReader(io.TeeReader(http1Data, &cloned))
+
+	// 1st request
+	req, err := http1parser.ReadRequest(true, r, &cloned)
+	require.NoError(t, err)
+	assert.NotEmpty(t, req.Header)
+	assert.Contains(t, req.Header, "lowercase")
+	assert.NotContains(t, req.Header, "Lowercase")
+
+	body, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	assert.Len(t, body, 17)
+	require.NoError(t, req.Body.Close())
+
+	// 2nd request
+	req, err = http1parser.ReadRequest(true, r, &cloned)
+	require.NoError(t, err)
+	assert.NotEmpty(t, req.Header)
+
+	assert.Equal(t, 0, r.Buffered())
+	assert.Equal(t, 0, cloned.Len())
+}

--- a/internal/http1parser/request_test.go
+++ b/internal/http1parser/request_test.go
@@ -3,15 +3,16 @@ package http1parser_test
 import (
 	"bufio"
 	"bytes"
+	"io"
+	"testing"
+
 	"github.com/elazarl/goproxy/internal/http1parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"io"
-	"testing"
 )
 
-func TestCanonicalRequest(t *testing.T) {
-	data := "POST /index.html HTTP/1.1\r\n" +
+const (
+	_data = "POST /index.html HTTP/1.1\r\n" +
 		"Host: www.test.com\r\n" +
 		"Accept: */*\r\n" +
 		"Content-Length: 17\r\n" +
@@ -19,14 +20,16 @@ func TestCanonicalRequest(t *testing.T) {
 		"\r\n" +
 		`{"hello":"world"}`
 
-	data2 := "GET /index.html HTTP/1.1\r\n" +
+	_data2 = "GET /index.html HTTP/1.1\r\n" +
 		"Host: www.test.com\r\n" +
 		"Accept: */*\r\n" +
 		"lowercase: 3z\r\n" +
 		"\r\n"
+)
 
+func TestCanonicalRequest(t *testing.T) {
 	// Here we are simulating two requests on the same connection
-	http1Data := bytes.NewReader(append([]byte(data), data2...))
+	http1Data := bytes.NewReader(append([]byte(_data), _data2...))
 
 	var cloned bytes.Buffer
 	r := bufio.NewReader(io.TeeReader(http1Data, &cloned))
@@ -54,14 +57,7 @@ func TestCanonicalRequest(t *testing.T) {
 }
 
 func TestNonCanonicalRequest(t *testing.T) {
-	http1Data := bytes.NewReader([]byte("POST /index.html HTTP/1.1\r\n" +
-		"Host: www.test.com\r\n" +
-		"Accept: */*\r\n" +
-		"Content-Length: 17\r\n" +
-		"lowercase: 3z\r\n" +
-		"\r\n" +
-		`{"hello":"world"}`),
-	)
+	http1Data := bytes.NewReader([]byte(_data))
 
 	var cloned bytes.Buffer
 	r := bufio.NewReader(io.TeeReader(http1Data, &cloned))
@@ -74,27 +70,11 @@ func TestNonCanonicalRequest(t *testing.T) {
 }
 
 func TestMultipleNonCanonicalRequests(t *testing.T) {
-	data := "POST /index.html HTTP/1.1\r\n" +
-		"Host: www.test.com\r\n" +
-		"Accept: */*\r\n" +
-		"Content-Length: 17\r\n" +
-		"lowercase: 3z\r\n" +
-		"\r\n" +
-		`{"hello":"world"}`
-
-	data2 := "GET /index.html HTTP/1.1\r\n" +
-		"Host: www.test.com\r\n" +
-		"Accept: */*\r\n" +
-		"lowercase: 3z\r\n" +
-		"\r\n"
-
-	// Here we are simulating two requests on the same connection
-	http1Data := bytes.NewReader(append([]byte(data), data2...))
+	http1Data := bytes.NewReader(append([]byte(_data), _data2...))
 
 	var cloned bytes.Buffer
 	r := bufio.NewReader(io.TeeReader(http1Data, &cloned))
 
-	// 1st request
 	req, err := http1parser.ReadRequest(true, r, &cloned)
 	require.NoError(t, err)
 	assert.NotEmpty(t, req.Header)
@@ -106,11 +86,10 @@ func TestMultipleNonCanonicalRequests(t *testing.T) {
 	assert.Len(t, body, 17)
 	require.NoError(t, req.Body.Close())
 
-	// 2nd request
 	req, err = http1parser.ReadRequest(true, r, &cloned)
 	require.NoError(t, err)
 	assert.NotEmpty(t, req.Header)
 
-	assert.Equal(t, 0, r.Buffered())
 	assert.Equal(t, 0, cloned.Len())
+	assert.Equal(t, 0, r.Buffered())
 }

--- a/proxy.go
+++ b/proxy.go
@@ -39,11 +39,11 @@ type ProxyHttpServer struct {
 	CertStore          CertStorage
 	KeepHeader         bool
 	AllowHTTP2         bool
-	// When PreventCanonicalization is true, the header value passed in
-	// the request are sent as they are to the destination server, instead of
-	// following the HTTP RFC.
-	// This is useful when the header aren't considered case-insensitive
-	// by the target server.
+	// When PreventCanonicalization is true, the header names present in
+	// the request sent through the proxy are directly passed to the destination server,
+	// instead of following the HTTP RFC for their canonicalization.
+	// This is useful when the header name isn't treated as a case-insensitive
+	// value by the target server, because they don't follow the specs.
 	PreventCanonicalization bool
 	// KeepAcceptEncoding, if true, prevents the proxy from dropping
 	// Accept-Encoding headers from the client.

--- a/proxy.go
+++ b/proxy.go
@@ -39,6 +39,12 @@ type ProxyHttpServer struct {
 	CertStore          CertStorage
 	KeepHeader         bool
 	AllowHTTP2         bool
+	// When PreventCanonicalization is true, the header value passed in
+	// the request are sent as they are to the destination server, instead of
+	// following the HTTP RFC.
+	// This is useful when the header aren't considered case-insensitive
+	// by the target server.
+	PreventCanonicalization bool
 	// KeepAcceptEncoding, if true, prevents the proxy from dropping
 	// Accept-Encoding headers from the client.
 	//

--- a/proxy.go
+++ b/proxy.go
@@ -1,8 +1,6 @@
 package goproxy
 
 import (
-	"bufio"
-	"errors"
 	"io"
 	"log"
 	"net"
@@ -67,11 +65,6 @@ func copyHeaders(dst, src http.Header, keepDestHeaders bool) {
 		// direct assignment to avoid canonicalization
 		dst[k] = append([]string(nil), vs...)
 	}
-}
-
-func isEOF(r *bufio.Reader) bool {
-	_, err := r.Peek(1)
-	return errors.Is(err, io.EOF)
 }
 
 func (proxy *ProxyHttpServer) filterRequest(r *http.Request, ctx *ProxyCtx) (req *http.Request, resp *http.Response) {


### PR DESCRIPTION
Fixes https://github.com/elazarl/goproxy/issues/559.
Thanks to a suggestion made by @alessiodallapiazza, I found this thread where they talk about the request canonicalization problem: https://github.com/golang/go/issues/37834.
Basically, if the request specifies an header value, the Go http parser can rewrite its name to make it compliant with the RFC standard, but this behavior will break some requests made to websites that expects a different case (e.g. everything lowercase) for the name.

In this PR I tried to implement a (not too ugly) solution for this problem.
I still rely on the standard Go implementation, which handles all the edge cases, but I duplicate the data stream to parse manually only a list of the header names by ourselves.
To extract headers I used a simplified version of https://github.com/evanphx/wildcat, modified by me.
Then, for each header, I manually replace the name saved inside the `Headers` map only if it's different than the canonicalized one.

I added some additional tests for everything.
Does someone want to review this? Is there some missing edge case?