### PR TITLE
Fix DstHostIs check

### DIFF
--- a/dispatcher.go
+++ b/dispatcher.go
@@ -134,8 +134,25 @@ func UrlMatches(re *regexp.Regexp) ReqConditionFunc {
 
 // DstHostIs returns a ReqCondition testing wether the host in the request url is the given string.
 func DstHostIs(host string) ReqConditionFunc {
+	// Make sure to perform a case-insensitive host check
 	host = strings.ToLower(host)
+	var port string
+
+	// Check if the user specified a custom port that we need to match
+	if strings.Contains(host, ":") {
+		hostOnly, portOnly, err := net.SplitHostPort(host)
+		if err == nil {
+			host = hostOnly
+			port = portOnly
+		}
+	}
+
 	return func(req *http.Request, ctx *ProxyCtx) bool {
+		// Check port matching only if it was specified
+		if port != "" && port != req.URL.Port() {
+			return false
+		}
+
 		return strings.ToLower(req.URL.Hostname()) == host
 	}
 }

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -136,7 +136,7 @@ func UrlMatches(re *regexp.Regexp) ReqConditionFunc {
 func DstHostIs(host string) ReqConditionFunc {
 	host = strings.ToLower(host)
 	return func(req *http.Request, ctx *ProxyCtx) bool {
-		return strings.ToLower(req.URL.Host) == host
+		return strings.ToLower(req.URL.Hostname()) == host
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/elazarl/goproxy/issues/301.
According to our documentation, DstHostIs "returns a ReqCondition testing wether the host in the request url is the given string".

However, in the Go [documentation](https://pkg.go.dev/net/url#URL), Host can contain the host or the host:port combo, leading to an undefined behaviour.

To fix this issue, I call the [Hostname](https://pkg.go.dev/net/url#URL.Hostname) method instead.
The user can also specify a port that we need to match, and in this case, its considered in the handler.