### PR TITLE
Inherit `go` version from `go.mod` file

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,13 +15,13 @@ jobs:
     env:
       CGO_ENABLED: 0
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
 
       # https://stackoverflow.com/questions/76269119/github-actions-go-lambda-project-different-sha256sums
       - name: Build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version-file: go.mod
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4


### PR DESCRIPTION
This way it's one less place the version needs to be bumped.

Whenever the minimum version in `go.mod` is bumped, that will be immediately reflected here.