### PR TITLE
Pre-emptively prevent test fixtures from lingering global state

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,9 @@ jobs:
         run: go build -v -buildvcs=false ./...
 
       - name: Test
-        run: go test -p 1 -v -shuffle=on ./...
+        # -count=2 ensures that test fixtures cleanup after themselves
+        # because any leftover state will generally cause the second run to fail.
+        run: go test -p 1 -v -shuffle=on -count=2 ./...
 
       - name: Linter
         uses: golangci/golangci-lint-action@v6


### PR DESCRIPTION
`count=2` is very effective at sniffing out global state/singletons that don't get unset properly by a test's cleanup.

We started doing this at a previous employer and discovered all sorts of tests that were leaving global singleton artifacts around and other tests had started to depend on them... it took a while to untangle, but we were very glad once we finally got through it.