### PR TITLE
Default to the `go` version in `go.mod`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 run:
   timeout: 5m
   modules-download-mode: readonly
-  go: '1.20'
 
 # List from https://golangci-lint.run/usage/linters/
 linters:


### PR DESCRIPTION
There's no need to pin the version here... the default is to inherit from the version in `go.mod`.

Docs here: https://golangci-lint.run/usage/configuration/

So removing it here helps ensure that the linter stays in-sync with what the library specifies as the minimum supported version.