### PR TITLE
redundant names are redundant

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,11 +13,9 @@ jobs:
     name: Build And Test Go code
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
+      - uses: actions/checkout@v4
+      
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
The actions names here are self-explanatory, no need to name them.

Plus the "checkout" name was slightly incorrect, as it checks out the full repo, and has nothing to do with the go modules directory.