### PR TITLE
Revert "Use same Subject of CA as the MITM certificate Subject"

### DIFF
--- a/internal/signer/signer.go
+++ b/internal/signer/signer.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -52,9 +53,11 @@ func SignHost(ca tls.Certificate, hosts []string) (cert *tls.Certificate, err er
 	template := x509.Certificate{
 		SerialNumber: big.NewInt(int64(generated)),
 		Issuer:       x509ca.Subject,
-		Subject:      x509ca.Subject,
-		NotBefore:    start,
-		NotAfter:     end,
+		Subject: pkix.Name{
+			Organization: []string{"GoProxy untrusted MITM proxy Inc"},
+		},
+		NotBefore: start,
+		NotAfter:  end,
 
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},


### PR DESCRIPTION
Fixes https://github.com/elazarl/goproxy/issues/627