### PR TITLE
Handle Websocket using standard library

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,9 +3,9 @@ module github.com/elazarl/goproxy/examples/goproxy-transparent
 go 1.20
 
 require (
-	github.com/elazarl/goproxy v1.3.0
-	github.com/elazarl/goproxy/ext v0.0.0-20250110140559-10fc34b80676
-	github.com/gorilla/websocket v1.5.3
+	github.com/coder/websocket v1.8.12
+	github.com/elazarl/goproxy v1.5.0
+	github.com/elazarl/goproxy/ext v0.0.0-20250117123040-e9229c451ab8
 	github.com/inconshreveable/go-vhost v1.0.0
 )
 

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1,8 +1,10 @@
+github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
+github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/elazarl/goproxy/ext v0.0.0-20250110140559-10fc34b80676 h1:3bAtOWqImclW/5rXbhNyAcM122jafst+/+4J4vC8wZI=
 github.com/elazarl/goproxy/ext v0.0.0-20250110140559-10fc34b80676/go.mod h1:q2JQCFWg+AQfe6O2cbf7LJDB48R68w+q0pBU53v02iM=
-github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
-github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/elazarl/goproxy/ext v0.0.0-20250117123040-e9229c451ab8 h1:rGxOExXmpBcmZc4ZnEXBGkcxSReZx7S9ECtuv6BtUYQ=
+github.com/elazarl/goproxy/ext v0.0.0-20250117123040-e9229c451ab8/go.mod h1:q2JQCFWg+AQfe6O2cbf7LJDB48R68w+q0pBU53v02iM=
 github.com/inconshreveable/go-vhost v1.0.0 h1:IK4VZTlXL4l9vz2IZoiSFbYaaqUW7dXJAiPriUN5Ur8=
 github.com/inconshreveable/go-vhost v1.0.0/go.mod h1:aA6DnFhALT3zH0y+A39we+zbrdMC2N0X/q21e6FI0LU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/http.go
+++ b/http.go
@@ -19,13 +19,6 @@ func (proxy *ProxyHttpServer) handleHttp(w http.ResponseWriter, r *http.Request)
 	r, resp := proxy.filterRequest(r, ctx)
 
 	if resp == nil {
-		if isWebSocketRequest(r) {
-			ctx.Logf("Request looks like websocket upgrade.")
-			if conn, err := proxy.hijackConnection(ctx, w); err == nil {
-				proxy.serveWebsocket(ctx, conn, r)
-			}
-		}
-
 		if !proxy.KeepHeader {
 			RemoveProxyHeaders(ctx, r)
 		}
@@ -73,6 +66,23 @@ func (proxy *ProxyHttpServer) handleHttp(w http.ResponseWriter, r *http.Request)
 	}
 	copyHeaders(w.Header(), resp.Header, proxy.KeepDestinationHeaders)
 	w.WriteHeader(resp.StatusCode)
+
+	if isWebSocketHandshake(resp.Header) {
+		ctx.Logf("Response looks like websocket upgrade.")
+
+		// We have already written the "101 Switching Protocols" response,
+		// now we hijack the connection to send WebSocket data
+		if clientConn, err := proxy.hijackConnection(ctx, w); err == nil {
+			wsConn, ok := resp.Body.(io.ReadWriter)
+			if !ok {
+				ctx.Warnf("Unable to use Websocket connection")
+				return
+			}
+			proxy.proxyWebsocket(ctx, wsConn, clientConn)
+		}
+		return
+	}
+
 	var copyWriter io.Writer = w
 	// Content-Type header may also contain charset definition, so here we need to check the prefix.
 	// Transfer-Encoding can be a list of comma separated values, so we use Contains() for it.

--- a/proxy.go
+++ b/proxy.go
@@ -119,7 +119,14 @@ func RemoveProxyHeaders(ctx *ProxyCtx, r *http.Request) {
 	if r.Header.Get("Connection") == "close" {
 		r.Close = false
 	}
-	r.Header.Del("Connection")
+
+	// We need to keep "Connection: upgrade" header, since it's part of
+	// the WebSocket handshake, and it won't work without it.
+	// For all the other cases (close, keep-alive), we already handle them, by
+	// setting the r.Close variable in the previous lines.
+	if !isWebSocketHandshake(r.Header) {
+		r.Header.Del("Connection")
+	}
 }
 
 type flushWriter struct {

--- a/websocket.go
+++ b/websocket.go
@@ -1,8 +1,6 @@
 package goproxy
 
 import (
-	"bufio"
-	"crypto/tls"
 	"errors"
 	"io"
 	"net"
@@ -21,48 +19,9 @@ func headerContains(header http.Header, name string, value string) bool {
 	return false
 }
 
-func isWebSocketRequest(r *http.Request) bool {
-	return headerContains(r.Header, "Connection", "upgrade") &&
-		headerContains(r.Header, "Upgrade", "websocket")
-}
-
-func (proxy *ProxyHttpServer) serveWebsocketTLS(
-	ctx *ProxyCtx,
-	req *http.Request,
-	tlsConfig *tls.Config,
-	clientConn *tls.Conn,
-) {
-	// wss
-	host := req.URL.Host
-	// Port is optional in req.URL.Host, in this case SplitHostPort returns
-	// an error, and we add the default port
-	_, port, err := net.SplitHostPort(req.URL.Host)
-	if err != nil || port == "" {
-		host = net.JoinHostPort(req.URL.Host, "443")
-	}
-
-	targetConn, err := proxy.connectDial(ctx, "tcp", host)
-	if err != nil {
-		ctx.Warnf("Error dialing target site: %v", err)
-		return
-	}
-	defer targetConn.Close()
-
-	// Add TLS to the raw TCP connection
-	targetConn, err = proxy.initializeTLSconnection(ctx, targetConn, tlsConfig, host)
-	if err != nil {
-		ctx.Warnf("Websocket TLS connection error: %v", err)
-		return
-	}
-
-	// Perform handshake
-	if err := proxy.websocketHandshake(ctx, req, targetConn, clientConn); err != nil {
-		ctx.Warnf("Websocket handshake error: %v", err)
-		return
-	}
-
-	// Proxy wss connection
-	proxy.proxyWebsocket(ctx, targetConn, clientConn)
+func isWebSocketHandshake(header http.Header) bool {
+	return headerContains(header, "Connection", "Upgrade") &&
+		headerContains(header, "Upgrade", "websocket")
 }
 
 func (proxy *ProxyHttpServer) hijackConnection(ctx *ProxyCtx, w http.ResponseWriter) (net.Conn, error) {
@@ -77,67 +36,6 @@ func (proxy *ProxyHttpServer) hijackConnection(ctx *ProxyCtx, w http.ResponseWri
 		return nil, err
 	}
 	return clientConn, nil
-}
-
-func (proxy *ProxyHttpServer) serveWebsocket(ctx *ProxyCtx, clientConn net.Conn, req *http.Request) {
-	// ws
-	host := req.URL.Host
-	// Port is optional in req.URL.Host, in this case SplitHostPort returns
-	// an error, and we add the default port
-	_, port, err := net.SplitHostPort(req.URL.Host)
-	if err != nil || port == "" {
-		host = net.JoinHostPort(req.URL.Host, "80")
-	}
-
-	targetConn, err := proxy.connectDial(ctx, "tcp", host)
-	if err != nil {
-		ctx.Warnf("Error dialing target site: %v", err)
-		return
-	}
-	defer targetConn.Close()
-
-	// Perform handshake
-	if err := proxy.websocketHandshake(ctx, req, targetConn, clientConn); err != nil {
-		ctx.Warnf("Websocket handshake error: %v", err)
-		return
-	}
-
-	// Proxy ws connection
-	proxy.proxyWebsocket(ctx, targetConn, clientConn)
-}
-
-func (proxy *ProxyHttpServer) websocketHandshake(
-	ctx *ProxyCtx,
-	req *http.Request,
-	targetSiteConn io.ReadWriter,
-	clientConn io.ReadWriter,
-) error {
-	// write handshake request to target
-	err := req.Write(targetSiteConn)
-	if err != nil {
-		ctx.Warnf("Error writing upgrade request: %v", err)
-		return err
-	}
-
-	targetTLSReader := bufio.NewReader(targetSiteConn)
-
-	// Read handshake response from target
-	resp, err := http.ReadResponse(targetTLSReader, req)
-	if err != nil {
-		ctx.Warnf("Error reading handhsake response  %v", err)
-		return err
-	}
-
-	// Run response through handlers
-	resp = proxy.filterResponse(resp, ctx)
-
-	// Proxy handshake back to client
-	err = resp.Write(clientConn)
-	if err != nil {
-		ctx.Warnf("Error writing handshake response: %v", err)
-		return err
-	}
-	return nil
 }
 
 func (proxy *ProxyHttpServer) proxyWebsocket(ctx *ProxyCtx, dest io.ReadWriter, source io.ReadWriter) {


### PR DESCRIPTION
Fixes https://github.com/elazarl/goproxy/issues/630.
Instead of relying on custom code to handshake WebSockets separately, just rely on the standard library response Body, as explained in the documentation.
This will also use a cascadeproxy configuration by default, without the need to setting a custom per-request Dialer, when the custom transport is configured with a proxy URL.

I also update the websocket example to use a more updated WebSocket client library.