### PR TITLE
Fix http request handling

### DIFF
--- a/http.go
+++ b/http.go
@@ -10,7 +10,6 @@ import (
 func (proxy *ProxyHttpServer) handleHttp(w http.ResponseWriter, r *http.Request) {
 	ctx := &ProxyCtx{Req: r, Session: atomic.AddInt64(&proxy.sess, 1), Proxy: proxy}
 
-	var err error
 	ctx.Logf("Got request %v %v %v %v", r.URL.Path, r.Host, r.Method, r.URL.String())
 	if !r.URL.IsAbs() {
 		proxy.NonproxyHandler.ServeHTTP(w, r)
@@ -25,17 +24,14 @@ func (proxy *ProxyHttpServer) handleHttp(w http.ResponseWriter, r *http.Request)
 				proxy.serveWebsocket(ctx, conn, r)
 			}
 		}
-
 		if !proxy.KeepHeader {
 			RemoveProxyHeaders(ctx, r)
 		}
+
+		var err error
 		resp, err = ctx.RoundTrip(r)
 		if err != nil {
 			ctx.Error = err
-			resp = proxy.filterResponse(nil, ctx)
-		}
-		if resp != nil {
-			ctx.Logf("Received response %v", resp.Status)
 		}
 	}
 

--- a/https.go
+++ b/https.go
@@ -210,9 +210,6 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 				return
 			}
 
-			// Take the original value before filtering the request
-			closeConn := req.Close
-
 			if requestOk := func(req *http.Request) bool {
 				// Since we handled the request parsing by our own, we manually
 				// need to set a cancellable context when we finished the request
@@ -263,11 +260,6 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 
 				return true
 			}(req); !requestOk {
-				break
-			}
-
-			if closeConn {
-				ctx.Logf("Non-persistent connection; closing")
 				break
 			}
 		}
@@ -321,9 +313,6 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 				if !strings.HasPrefix(req.URL.String(), "https://") {
 					req.URL, err = url.Parse("https://" + r.Host + req.URL.String())
 				}
-
-				// Take the original value before filtering the request
-				closeConn := req.Close
 
 				if continueLoop := func(req *http.Request) bool {
 					// Since we handled the request parsing by our own, we manually
@@ -457,11 +446,6 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 
 					return true
 				}(req); !continueLoop {
-					return
-				}
-
-				if closeConn {
-					ctx.Logf("Non-persistent connection; closing")
 					return
 				}
 			}

--- a/proxy.go
+++ b/proxy.go
@@ -110,15 +110,6 @@ func RemoveProxyHeaders(ctx *ProxyCtx, r *http.Request) {
 	//   options that are desired for that particular connection and MUST NOT
 	//   be communicated by proxies over further connections.
 
-	// When server reads http request it sets req.Close to true if
-	// "Connection" header contains "close".
-	// https://github.com/golang/go/blob/master/src/net/http/request.go#L1080
-	// Later, transfer.go adds "Connection: close" back when req.Close is true
-	// https://github.com/golang/go/blob/master/src/net/http/transfer.go#L275
-	// That's why tests that checks "Connection: close" removal fail
-	if r.Header.Get("Connection") == "close" {
-		r.Close = false
-	}
 	r.Header.Del("Connection")
 }
 


### PR DESCRIPTION
Currently we're calling the http response filter twice for the same request, as explained here: https://github.com/superfly/tokenizer/blob/a17a2e0a9dc0c37014e3477b977a4dd812bd23d1/tokenizer.go#L188.
We want to avoid that and in this pull request I remove the redundant one.

Moreover, when we receive the "Connection: close" header, we must wait for the client to close its connection, according to [RFC9112](https://httpwg.org/specs/rfc9112.html#persistent.tear-down), or there will be some issues with its response read. I therefore rollback the changes where we did an early return in the presence of this header and just wait for the client connection close.