### PR TITLE
Call ConnectionErrHandler for MITM TLS handshake errors

### DIFF
--- a/https.go
+++ b/https.go
@@ -286,6 +286,9 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 			defer rawClientTls.Close()
 			if err := rawClientTls.Handshake(); err != nil {
 				ctx.Warnf("Cannot handshake client %v %v", r.Host, err)
+				if proxy.ConnectionErrHandler != nil {
+					proxy.ConnectionErrHandler(proxyClient, ctx, err)
+				}
 				return
 			}
 


### PR DESCRIPTION
`ConnectionErrHandler` is being called for a couple other error cases in this file, but not for TLS handshake errors specifically. I assume this was an oversight, because I otherwise couldn't find any other way of (easily) detecting TLS handshake errors via goproxy.

After making this change, I could confirm it was executing on handshake errors as expected -- I needed this to detect SSL pinning in a small network capture app.