### PR TITLE
SignHost: Fall back to ECDSA when CA key type cannot be imitated

### DIFF
--- a/internal/signer/counterecryptor.go
+++ b/internal/signer/counterecryptor.go
@@ -5,10 +5,10 @@ import (
 	"crypto/cipher"
 	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
-	"errors"
 )
 
 type CounterEncryptorRand struct {
@@ -32,7 +32,7 @@ func NewCounterEncryptorRandFromKey(key any, seed []byte) (r CounterEncryptorRan
 			return
 		}
 	default:
-		return r, errors.New("only RSA, ED25519 and ECDSA keys supported")
+		rand.Read(keyBytes)
 	}
 	h := sha256.New()
 	if r.cipher, err = aes.NewCipher(h.Sum(keyBytes)[:aes.BlockSize]); err != nil {

--- a/internal/signer/signer.go
+++ b/internal/signer/signer.go
@@ -10,7 +10,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"fmt"
 	"math/big"
 	"math/rand"
 	"net"
@@ -93,7 +92,9 @@ func SignHost(ca tls.Certificate, hosts []string) (cert *tls.Certificate, err er
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("unsupported key type %T", ca.PrivateKey)
+		if certpriv, err = ecdsa.GenerateKey(elliptic.P256(), &csprng); err != nil {
+			return nil, err
+		}
 	}
 
 	derBytes, err := x509.CreateCertificate(&csprng, &template, x509ca, certpriv.Public(), ca.PrivateKey)


### PR DESCRIPTION
This primarily becomes relevant when the CA key is backed by a KMS like a TPM chip or a YubiKey (like in [this project](https://github.com/orbit-online/step-kmsproxy-plugin)).

I have kept the PR intentionally simple for now. I'm guessing we need some tests, and perhaps logging that we are using a fallback could be relevant.

Note that the `rand.Read()` makes the key generation for certificates non-deterministic and might also affect performance when connecting for the first time (assuming `CertStorage` is used).