### PR TITLE
Send 100-continue before reading body in HTTPS proxy handling

### DIFF
--- a/https.go
+++ b/https.go
@@ -306,6 +306,13 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 					return
 				}
 
+				// When receiving an Expect: 100-continue header from the client, we need to respond
+				// with a 100 Continue status code before we can read the body of the request.
+				// Some clients will wait for the 100 Continue response before sending the body.
+				if req.Header.Get("Expect") == "100-continue" {
+					io.WriteString(rawClientTls, "HTTP/1.1 100 Continue\r\n\r\n")
+				}
+
 				// since we're converting the request, need to carry over the
 				// original connecting IP as well
 				req.RemoteAddr = r.RemoteAddr


### PR DESCRIPTION
This was forklifted from https://github.com/nnarayen/goproxy/commit/a86b63a99ea0e03228a0483dba43ddc4af1eab2a.

As the comment says, when the proxy receives a request with an "Expect: 100-continue" header, it should respond with a "100 Continue" status code before reading the body of the request. Some clients, like aws-sdk (by default), will wait for this response before sending the body.

I removed the stripping of the `Expect` header because I'm unsure if that really needs to be done or not. I think it might be best to continue to send the header even if the proxy tells the client to continue

Overall I'm unsure if this is the best solution, but I'm not sure where else to go. I wonder if the Expect should actually be forwarded to the proxied server and the proxied server should reply first rather than the proxy telling the client to immediately go forward.