### PR TITLE
Merge HTTPMitmConnect and MitmConnect actions

### DIFF
--- a/https.go
+++ b/https.go
@@ -26,18 +26,31 @@ const (
 	ConnectReject
 	ConnectMitm
 	ConnectHijack
+	// Deprecated: use ConnectMitm.
 	ConnectHTTPMitm
 	ConnectProxyAuthHijack
 )
 
 var (
-	OkConnect       = &ConnectAction{Action: ConnectAccept, TLSConfig: TLSConfigFromCA(&GoproxyCa)}
-	MitmConnect     = &ConnectAction{Action: ConnectMitm, TLSConfig: TLSConfigFromCA(&GoproxyCa)}
+	OkConnect   = &ConnectAction{Action: ConnectAccept, TLSConfig: TLSConfigFromCA(&GoproxyCa)}
+	MitmConnect = &ConnectAction{Action: ConnectMitm, TLSConfig: TLSConfigFromCA(&GoproxyCa)}
+	// Deprecated: use MitmConnect.
 	HTTPMitmConnect = &ConnectAction{Action: ConnectHTTPMitm, TLSConfig: TLSConfigFromCA(&GoproxyCa)}
 	RejectConnect   = &ConnectAction{Action: ConnectReject, TLSConfig: TLSConfigFromCA(&GoproxyCa)}
 )
 
 var _errorRespMaxLength int64 = 500
+
+const _tlsRecordTypeHandshake = byte(22)
+
+type readBufferedConn struct {
+	net.Conn
+	r io.Reader
+}
+
+func (c *readBufferedConn) Read(p []byte) (int, error) {
+	return c.r.Read(p)
+}
 
 // ConnectAction enables the caller to override the standard connect flow.
 // When Action is ConnectHijack, it is up to the implementer to send the
@@ -193,104 +206,50 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 
 	case ConnectHijack:
 		todo.Hijack(r, proxyClient, ctx)
-	case ConnectHTTPMitm:
+	case ConnectHTTPMitm, ConnectMitm:
 		_, _ = proxyClient.Write([]byte("HTTP/1.0 200 OK\r\n\r\n"))
-		ctx.Logf("Assuming CONNECT is plain HTTP tunneling, mitm proxying it")
-
-		var targetSiteCon net.Conn
-		var remote *bufio.Reader
-
-		client := http1parser.NewRequestReader(proxy.PreventCanonicalization, proxyClient)
-		for !client.IsEOF() {
-			req, err := client.ReadRequest()
-			if err != nil && !errors.Is(err, io.EOF) {
-				ctx.Warnf("cannot read request of MITM HTTP client: %+#v", err)
-			}
-			if err != nil {
-				return
-			}
-
-			if requestOk := func(req *http.Request) bool {
-				// Since we handled the request parsing by our own, we manually
-				// need to set a cancellable context when we finished the request
-				// processing (same behaviour of the stdlib)
-				requestContext, finishRequest := context.WithCancel(req.Context())
-				req = req.WithContext(requestContext)
-				defer finishRequest()
-
-				// since we're converting the request, need to carry over the
-				// original connecting IP as well
-				req.RemoteAddr = r.RemoteAddr
-				ctx.Logf("req %v", r.Host)
-				ctx.Req = req
-
-				req, resp := proxy.filterRequest(req, ctx)
-				if resp == nil {
-					// Establish a connection with the remote server only if the proxy
-					// doesn't produce a response
-					if targetSiteCon == nil {
-						targetSiteCon, err = proxy.connectDial(ctx, "tcp", host)
-						if err != nil {
-							ctx.Warnf("Error dialing to %s: %s", host, err.Error())
-							return false
-						}
-						remote = bufio.NewReader(targetSiteCon)
-					}
-
-					if err := req.Write(targetSiteCon); err != nil {
-						httpError(proxyClient, ctx, err)
-						return false
-					}
-					resp, err = func() (*http.Response, error) {
-						defer req.Body.Close()
-						return http.ReadResponse(remote, req)
-					}()
-					if err != nil {
-						httpError(proxyClient, ctx, err)
-						return false
-					}
-				}
-				resp = proxy.filterResponse(resp, ctx)
-				defer resp.Body.Close()
-
-				err = resp.Write(proxyClient)
-				if err != nil {
-					httpError(proxyClient, ctx, err)
-					return false
-				}
-
-				return true
-			}(req); !requestOk {
-				break
-			}
-		}
-	case ConnectMitm:
-		_, _ = proxyClient.Write([]byte("HTTP/1.0 200 OK\r\n\r\n"))
-		ctx.Logf("Assuming CONNECT is TLS, mitm proxying it")
+		ctx.Logf("Received CONNECT request, mitm proxying it")
 		// this goes in a separate goroutine, so that the net/http server won't think we're
 		// still handling the request even after hijacking the connection. Those HTTP CONNECT
 		// request can take forever, and the server will be stuck when "closed".
 		// TODO: Allow Server.Close() mechanism to shut down this connection as nicely as possible
-		tlsConfig := defaultTLSConfig
-		if todo.TLSConfig != nil {
-			var err error
-			tlsConfig, err = todo.TLSConfig(host, ctx)
-			if err != nil {
-				httpError(proxyClient, ctx, err)
-				return
-			}
-		}
 		go func() {
-			rawClientTls := tls.Server(proxyClient, tlsConfig)
-			defer rawClientTls.Close()
-			if err := rawClientTls.HandshakeContext(context.Background()); err != nil {
-				ctx.Warnf("Cannot handshake client %v %v", r.Host, err)
-				return
+			// Check if this is an HTTP or an HTTPS MITM request
+			readBuffer := bufio.NewReader(proxyClient)
+			peek, _ := readBuffer.Peek(1)
+			isTLS := len(peek) > 0 && peek[0] == _tlsRecordTypeHandshake
+
+			var client net.Conn = &readBufferedConn{Conn: proxyClient, r: readBuffer}
+			defer func() {
+				_ = client.Close()
+			}()
+
+			var tlsConfig *tls.Config
+			scheme := "http"
+			if isTLS {
+				scheme = "https"
+				tlsConfig = defaultTLSConfig
+				if todo.TLSConfig != nil {
+					var err error
+					tlsConfig, err = todo.TLSConfig(host, ctx)
+					if err != nil {
+						httpError(proxyClient, ctx, err)
+						return
+					}
+				}
+
+				// Create a TLS connection over the TCP connection
+				rawClientTls := tls.Server(client, tlsConfig)
+				client = rawClientTls
+				if err := rawClientTls.HandshakeContext(context.Background()); err != nil {
+					ctx.Warnf("Cannot handshake client %v %v", r.Host, err)
+					return
+				}
 			}
 
-			clientTlsReader := http1parser.NewRequestReader(proxy.PreventCanonicalization, rawClientTls)
-			for !clientTlsReader.IsEOF() {
-				req, err := clientTlsReader.ReadRequest()
+			clientReader := http1parser.NewRequestReader(proxy.PreventCanonicalization, client)
+			for !clientReader.IsEOF() {
+				req, err := clientReader.ReadRequest()
 				ctx := &ProxyCtx{
 					Req:          req,
 					Session:      atomic.AddInt64(&proxy.sess, 1),
@@ -299,7 +258,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 					RoundTripper: ctx.RoundTripper,
 				}
 				if err != nil && !errors.Is(err, io.EOF) {
-					ctx.Warnf("Cannot read TLS request from mitm'd client %v %v", r.Host, err)
+					ctx.Warnf("Cannot read request from mitm'd client %v %v", r.Host, err)
 				}
 				if err != nil {
 					return
@@ -310,8 +269,8 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 				req.RemoteAddr = r.RemoteAddr
 				ctx.Logf("req %v", r.Host)
 
-				if !strings.HasPrefix(req.URL.String(), "https://") {
-					req.URL, err = url.Parse("https://" + r.Host + req.URL.String())
+				if !strings.HasPrefix(req.URL.String(), scheme+"://") {
+					req.URL, err = url.Parse(scheme + "://" + r.Host + req.URL.String())
 				}
 
 				if continueLoop := func(req *http.Request) bool {
@@ -335,7 +294,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 							// parse the HTTP Body for PRI requests. This leaves the body of
 							// the http2.ClientPreface ("SM\r\n\r\n") on the wire which we need
 							// to clear before setting up the connection.
-							reader := clientTlsReader.Reader()
+							reader := clientReader.Reader()
 							_, err := reader.Discard(6)
 							if err != nil {
 								ctx.Warnf("Failed to process HTTP2 client preface: %v", err)
@@ -345,7 +304,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 								ctx.Warnf("HTTP2 connection failed: disallowed")
 								return false
 							}
-							tr := H2Transport{reader, rawClientTls, tlsConfig.Clone(), host}
+							tr := H2Transport{reader, client, tlsConfig, host}
 							if _, err := tr.RoundTrip(req); err != nil {
 								ctx.Warnf("HTTP2 connection failed: %v", err)
 							} else {
@@ -355,9 +314,9 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 						}
 						if err != nil {
 							if req.URL != nil {
-								ctx.Warnf("Illegal URL %s", "https://"+r.Host+req.URL.Path)
+								ctx.Warnf("Illegal URL %s", scheme+"://"+r.Host+req.URL.Path)
 							} else {
-								ctx.Warnf("Illegal URL %s", "https://"+r.Host)
+								ctx.Warnf("Illegal URL %s", scheme+"://"+r.Host)
 							}
 							return false
 						}
@@ -371,7 +330,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 							return ctx.RoundTrip(req)
 						}()
 						if err != nil {
-							ctx.Warnf("Cannot read TLS response from mitm'd server %v", err)
+							ctx.Warnf("Cannot read response from mitm'd server %v", err)
 							return false
 						}
 						ctx.Logf("resp %v", resp.Status)
@@ -403,16 +362,16 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 						// and returns immediately without blocking on the body
 						// (or else we wouldn't be able to proxy WebSocket data).
 						resp.Body = nil
-						if err := resp.Write(rawClientTls); err != nil {
-							ctx.Warnf("Cannot write TLS response header from mitm'd client: %v", err)
+						if err := resp.Write(client); err != nil {
+							ctx.Warnf("Cannot write response header from mitm'd client: %v", err)
 							return false
 						}
-						proxy.proxyWebsocket(ctx, wsConn, rawClientTls)
+						proxy.proxyWebsocket(ctx, wsConn, client)
 						return false
 					}
 
-					if err := resp.Write(rawClientTls); err != nil {
-						ctx.Warnf("Cannot write TLS response from mitm'd client: %v", err)
+					if err := resp.Write(client); err != nil {
+						ctx.Warnf("Cannot write response from mitm'd client: %v", err)
 						return false
 					}
 
@@ -500,7 +459,7 @@ func (proxy *ProxyHttpServer) NewConnectDialToProxyWithHandler(
 	if err != nil {
 		return nil
 	}
-	if u.Scheme == "" || u.Scheme == "http" {
+	if u.Scheme == "" || u.Scheme == "http" || u.Scheme == "ws" {
 		if !strings.ContainsRune(u.Host, ':') {
 			u.Host += ":80"
 		}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -744,7 +744,7 @@ func writeConnect(w io.Writer) {
 func TestCurlMinusP(t *testing.T) {
 	proxy := goproxy.NewProxyHttpServer()
 	proxy.OnRequest().HandleConnectFunc(func(host string, ctx *goproxy.ProxyCtx) (*goproxy.ConnectAction, string) {
-		return goproxy.HTTPMitmConnect, host
+		return goproxy.MitmConnect, host
 	})
 	called := false
 	proxy.OnRequest().DoFunc(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {


### PR DESCRIPTION
In this pull request I'm unifying HTTP MITM and HTTPS MITM inside a single connect action.
This was a really requested change and I was planning it since a long time.
Thanks to this change, MITM usage is much more easier to use and less error prone, the correct one is chosen based on the first received byte, to check if the request contains a TLS Handshake Client Hello.
This also avoids code duplication and add the HTTPS MITM features that were missing to the HTTP MITM (like WebSockets support).