### PR TITLE
Fix MITM responses leaking upstream HTTP/2 protocol version

### DIFF
--- a/https.go
+++ b/https.go
@@ -349,6 +349,14 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 						resp.TransferEncoding = []string{"chunked"}
 					}
 
+					// The MITM'd client speaks HTTP/1.1, but the upstream
+					// response may have been received over HTTP/2. Normalize
+					// the protocol version so resp.Write() produces a valid
+					// HTTP/1.1 status line.
+					resp.Proto = "HTTP/1.1"
+					resp.ProtoMajor = 1
+					resp.ProtoMinor = 1
+
 					if isWebSocketHandshake(resp.Header) {
 						ctx.Logf("Response looks like websocket upgrade.")
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1393,12 +1393,12 @@ func TestMITMResponseHTTP2ProtoVersion(t *testing.T) {
 
 	// Client talks HTTP/1.1 through the MITM proxy
 	proxyURL, _ := url.Parse(proxySrv.URL)
-	conn, err := net.Dial("tcp", proxyURL.Host)
+	conn, err := net.DialContext(context.Background(), "tcp", proxyURL.Host)
 	require.NoError(t, err)
 	defer conn.Close()
 
 	// Send CONNECT
-	connectReq, _ := http.NewRequest(http.MethodConnect, srv.URL, nil)
+	connectReq, _ := http.NewRequestWithContext(context.Background(), http.MethodConnect, srv.URL, nil)
 	require.NoError(t, connectReq.Write(conn))
 	br := bufio.NewReader(conn)
 	connectResp, err := http.ReadResponse(br, connectReq)
@@ -1407,10 +1407,10 @@ func TestMITMResponseHTTP2ProtoVersion(t *testing.T) {
 
 	// TLS handshake with the MITM'd proxy
 	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
-	require.NoError(t, tlsConn.Handshake())
+	require.NoError(t, tlsConn.HandshakeContext(context.Background()))
 
 	// Send an HTTP/1.1 request through the tunnel
-	httpReq, _ := http.NewRequest(http.MethodGet, srv.URL+"/test", nil)
+	httpReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/test", nil)
 	require.NoError(t, httpReq.Write(tlsConn))
 
 	// Read response — must be HTTP/1.x, not HTTP/2.0

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1393,7 +1393,7 @@ func TestMITMResponseHTTP2ProtoVersion(t *testing.T) {
 
 	// Client talks HTTP/1.1 through the MITM proxy
 	proxyURL, _ := url.Parse(proxySrv.URL)
-	conn, err := net.DialContext(context.Background(), "tcp", proxyURL.Host)
+	conn, err := (&net.Dialer{}).DialContext(context.Background(), "tcp", proxyURL.Host)
 	require.NoError(t, err)
 	defer conn.Close()
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1364,3 +1364,63 @@ func TestPersistentMitmRequest(t *testing.T) {
 		}
 	}
 }
+
+func TestMITMResponseHTTP2ProtoVersion(t *testing.T) {
+	// Upstream HTTP/2 server
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello"))
+	})
+	srv := httptest.NewUnstartedServer(handler)
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+	defer srv.Close()
+
+	// Proxy with MITM and HTTP/2 upstream transport
+	proxy := goproxy.NewProxyHttpServer()
+	proxy.OnRequest().HandleConnect(goproxy.AlwaysMitm)
+	proxy.Tr = &http.Transport{
+		ForceAttemptHTTP2: true,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+			NextProtos:         []string{"h2"},
+		},
+	}
+
+	proxySrv := httptest.NewServer(proxy)
+	defer proxySrv.Close()
+
+	// Client talks HTTP/1.1 through the MITM proxy
+	proxyURL, _ := url.Parse(proxySrv.URL)
+	conn, err := net.Dial("tcp", proxyURL.Host)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Send CONNECT
+	connectReq, _ := http.NewRequest(http.MethodConnect, srv.URL, nil)
+	require.NoError(t, connectReq.Write(conn))
+	br := bufio.NewReader(conn)
+	connectResp, err := http.ReadResponse(br, connectReq)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, connectResp.StatusCode)
+
+	// TLS handshake with the MITM'd proxy
+	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+	require.NoError(t, tlsConn.Handshake())
+
+	// Send an HTTP/1.1 request through the tunnel
+	httpReq, _ := http.NewRequest(http.MethodGet, srv.URL+"/test", nil)
+	require.NoError(t, httpReq.Write(tlsConn))
+
+	// Read response — must be HTTP/1.x, not HTTP/2.0
+	tlsBr := bufio.NewReader(tlsConn)
+	resp, err := http.ReadResponse(tlsBr, httpReq)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, "hello", string(body))
+	assert.Equal(t, 1, resp.ProtoMajor,
+		"MITM'd client should receive HTTP/1.x response, got %s", resp.Proto)
+}


### PR DESCRIPTION
Firstly, thank you for this project!

When bumping from 1.7.2 to 1.8.2 I hit an issue with MITM-ing a connection between an HTTP/1 client and an HTTP/2 server.

I'm afraid the rest of this is from an AI - please do let me know if anything needs de-slop-ing, but I think it's sane.

---

When the proxy connects to an upstream server over HTTP/2, the `http.Response` has Proto "HTTP/2.0".

Commit 78c76be5 ("Fix keep alive logic and replace legacy response write logic") switched from manually writing "HTTP/1.1" status lines to using resp.Write(), and commit b343a9ac ("Merge HTTPMitmConnect and MitmConnect actions") unified both MITM code paths.

Together, these changes cause the upstream protocol version to be preserved verbatim, writing "HTTP/2.0 200 OK" to the MITM'd client which speaks HTTP/1.1 over the hijacked connection. This causes clients to reject or reset the connection.

Normalize resp.Proto to HTTP/1.1 before calling resp.Write() in the MITM handler, since in this code path the client-facing connection is always HTTP/1.1.