### PR TITLE
feat: add brotli content encoding support

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -1,0 +1,71 @@
+package goproxy
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+
+	"github.com/andybalholm/brotli"
+)
+
+// decompressResponse transparently decompresses the response body based on
+// Content-Encoding when the proxy itself injected the Accept-Encoding header.
+// This mirrors what net/http.Transport does for gzip, extended to also cover
+// brotli (br).
+//
+// The function is a no-op when:
+//   - the client set its own Accept-Encoding (KeepAcceptEncoding=true)
+//   - the response has no body (HEAD, 204, 304)
+//   - the Content-Encoding is not one we handle
+func decompressResponse(resp *http.Response, req *http.Request) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+
+	// Only decompress if there's a body to read.
+	if req.Method == http.MethodHead || resp.ContentLength == 0 {
+		return
+	}
+
+	switch resp.Header.Get("Content-Encoding") {
+	case "br":
+		resp.Header.Del("Content-Encoding")
+		resp.Header.Del("Content-Length")
+		resp.ContentLength = -1
+		resp.Body = &readCloseWrapper{
+			Reader: brotli.NewReader(resp.Body),
+			Closer: resp.Body,
+		}
+		resp.Uncompressed = true
+
+	case "gzip":
+		// net/http.Transport usually handles gzip itself, but when the
+		// proxy explicitly sets Accept-Encoding (e.g. "gzip, br"), the
+		// transport sees a user-set header and skips its own
+		// decompression. Handle it here as a safety net.
+		gr, err := gzip.NewReader(resp.Body)
+		if err != nil {
+			return // leave body as-is on error
+		}
+		resp.Header.Del("Content-Encoding")
+		resp.Header.Del("Content-Length")
+		resp.ContentLength = -1
+		resp.Body = &readCloseWrapper{
+			Reader: gr,
+			Closer: resp.Body,
+		}
+		resp.Uncompressed = true
+	}
+}
+
+// readCloseWrapper combines an io.Reader (the decompressor) with the
+// underlying body's Close method so that closing the wrapper drains
+// and closes the original transport body.
+type readCloseWrapper struct {
+	io.Reader
+	Closer io.Closer
+}
+
+func (r *readCloseWrapper) Close() error {
+	return r.Closer.Close()
+}

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -1,0 +1,125 @@
+package goproxy
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/andybalholm/brotli"
+)
+
+func TestDecompressResponse_Brotli(t *testing.T) {
+	original := "Hello, brotli-compressed world!"
+
+	// Compress with brotli
+	var buf bytes.Buffer
+	bw := brotli.NewWriter(&buf)
+	bw.Write([]byte(original))
+	bw.Close()
+
+	resp := &http.Response{
+		StatusCode:    200,
+		Header:        http.Header{"Content-Encoding": {"br"}},
+		Body:          io.NopCloser(&buf),
+		ContentLength: int64(buf.Len()),
+	}
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+
+	decompressResponse(resp, req)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != original {
+		t.Errorf("expected %q, got %q", original, string(body))
+	}
+	if resp.Header.Get("Content-Encoding") != "" {
+		t.Error("Content-Encoding header should be removed")
+	}
+	if resp.ContentLength != -1 {
+		t.Errorf("ContentLength should be -1, got %d", resp.ContentLength)
+	}
+	if !resp.Uncompressed {
+		t.Error("Uncompressed should be true")
+	}
+}
+
+func TestDecompressResponse_Gzip(t *testing.T) {
+	original := "Hello, gzip-compressed world!"
+
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	gw.Write([]byte(original))
+	gw.Close()
+
+	resp := &http.Response{
+		StatusCode:    200,
+		Header:        http.Header{"Content-Encoding": {"gzip"}},
+		Body:          io.NopCloser(&buf),
+		ContentLength: int64(buf.Len()),
+	}
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+
+	decompressResponse(resp, req)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != original {
+		t.Errorf("expected %q, got %q", original, string(body))
+	}
+	if resp.Header.Get("Content-Encoding") != "" {
+		t.Error("Content-Encoding header should be removed")
+	}
+	if !resp.Uncompressed {
+		t.Error("Uncompressed should be true")
+	}
+}
+
+func TestDecompressResponse_Identity(t *testing.T) {
+	original := "Hello, uncompressed world!"
+
+	resp := &http.Response{
+		StatusCode:    200,
+		Header:        http.Header{},
+		Body:          io.NopCloser(bytes.NewBufferString(original)),
+		ContentLength: int64(len(original)),
+	}
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+
+	decompressResponse(resp, req)
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != original {
+		t.Errorf("expected %q, got %q", original, string(body))
+	}
+	if resp.ContentLength != int64(len(original)) {
+		t.Error("ContentLength should not be modified for uncompressed response")
+	}
+}
+
+func TestDecompressResponse_HeadRequest(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Encoding": {"br"}},
+		Body:       io.NopCloser(bytes.NewBuffer(nil)),
+	}
+	req, _ := http.NewRequest("HEAD", "http://example.com", nil)
+
+	// Should be a no-op for HEAD requests
+	decompressResponse(resp, req)
+
+	if resp.Header.Get("Content-Encoding") != "br" {
+		t.Error("Content-Encoding should not be modified for HEAD requests")
+	}
+}
+
+func TestDecompressResponse_NilResponse(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+	// Should not panic
+	decompressResponse(nil, req)
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 )
 
 require (
+	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/text v0.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
+github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/http.go
+++ b/http.go
@@ -27,6 +27,12 @@ func (proxy *ProxyHttpServer) handleHttp(w http.ResponseWriter, r *http.Request)
 		if err != nil {
 			ctx.Error = err
 		}
+
+		// Transparently decompress brotli/gzip responses when the proxy
+		// injected Accept-Encoding (KeepAcceptEncoding=false, the default).
+		if resp != nil && !proxy.KeepAcceptEncoding {
+			decompressResponse(resp, r)
+		}
 	}
 
 	var origBody io.ReadCloser

--- a/https.go
+++ b/https.go
@@ -333,6 +333,11 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 							return false
 						}
 						ctx.Logf("resp %v", resp.Status)
+
+						// Transparently decompress brotli/gzip for MITM'd HTTPS responses.
+						if !proxy.KeepAcceptEncoding {
+							decompressResponse(resp, req)
+						}
 					}
 					origBody := resp.Body
 					resp = proxy.filterResponse(resp, ctx)

--- a/proxy.go
+++ b/proxy.go
@@ -94,9 +94,18 @@ func RemoveProxyHeaders(ctx *ProxyCtx, r *http.Request) {
 	r.RequestURI = "" // this must be reset when serving a request with the client
 	ctx.Logf("Sending request %v %v", r.Method, r.URL.String())
 	if !ctx.Proxy.KeepAcceptEncoding {
-		// If no Accept-Encoding header exists, Transport will add the headers it can accept
-		// and would wrap the response body with the relevant reader.
-		r.Header.Del("Accept-Encoding")
+		if ctx.Proxy.Tr != nil && ctx.Proxy.Tr.DisableCompression {
+			// User explicitly disabled compression — strip the header
+			// entirely so no encoding is negotiated.
+			r.Header.Del("Accept-Encoding")
+		} else {
+			// Replace the client's Accept-Encoding with the encodings
+			// the proxy can transparently decompress: gzip and brotli.
+			// Setting this explicitly also prevents net/http.Transport
+			// from adding its own gzip-only header, which would bypass
+			// our decompression layer.
+			r.Header.Set("Accept-Encoding", "gzip, br")
+		}
 	}
 	// curl can add that, see
 	// https://jdebp.eu./FGA/web-proxy-connection-header.html

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -508,8 +508,8 @@ func TestAcceptEncoding(t *testing.T) {
 		acceptEncoding     string
 		expectedValue      string
 	}{
-		{false, false, "", "gzip"},
-		{false, false, "identity", "gzip"},
+		{false, false, "", "gzip, br"},
+		{false, false, "identity", "gzip, br"},
 		{false, true, "", ""},
 		{false, true, "identity", ""},
 		{true, false, "", "gzip"},


### PR DESCRIPTION
Closes #697

## Summary

Adds transparent brotli (`br`) decompression for proxied responses, extending the existing gzip-only behavior. This is the most widely deployed content encoding after gzip — supported by all modern browsers and CDNs (Cloudflare, AWS, Akamai all serve brotli by default).

## How it works

When `KeepAcceptEncoding` is `false` (the default), the proxy now advertises `Accept-Encoding: gzip, br` to upstream servers. Brotli-encoded responses are transparently decompressed before being passed to response handlers — matching the existing gzip behavior that Go's `http.Transport` provides.

```
Client → Proxy → Upstream
                  Accept-Encoding: gzip, br
                  ←── Content-Encoding: br (brotli)
         Proxy decompresses transparently
Client ←── plain response body
```

## Changes

| File | Change |
|------|--------|
| `encoding.go` | New `decompressResponse()` — handles `br` and `gzip` Content-Encoding |
| `proxy.go` | `RemoveProxyHeaders` sends `gzip, br`; respects `DisableCompression` |
| `http.go` | Wire decompression into HTTP response pipeline |
| `https.go` | Wire decompression into HTTPS MITM response pipeline |
| `encoding_test.go` | Unit tests: brotli, gzip, identity, HEAD, nil response |
| `proxy_test.go` | Update Accept-Encoding expectations |

## Design decisions

- **Pure Go brotli** (`andybalholm/brotli`) — no CGo, no system dependencies
- **Same pattern as stdlib** — mirrors how `net/http.Transport` handles gzip internally (strip Content-Encoding, set ContentLength=-1, wrap body reader)
- **Respects `DisableCompression`** — when `Tr.DisableCompression` is true, no Accept-Encoding is sent
- **Works for both HTTP and HTTPS MITM** — decompression is wired into both paths

## Tests

5 new unit tests covering brotli, gzip, identity, HEAD requests, and nil response handling. All existing `TestAcceptEncoding` subtests updated and passing.

Note: `TestSimpleHttpRequest` fails on `main` as well (pre-existing, tries to connect to localhost:5000).