### PR TITLE
http2: set ServerName for upstream TLS client

### DIFF
--- a/h2.go
+++ b/h2.go
@@ -33,15 +33,28 @@ func (r *H2Transport) RoundTrip(_ *http.Request) (*http.Response, error) {
 	if !strings.Contains(raddr, ":") {
 		raddr += ":443"
 	}
+	serverName := r.Host
+	if host, _, err := net.SplitHostPort(raddr); err == nil {
+		serverName = host
+	}
 	rawServerTLS, err := dial("tcp", raddr)
 	if err != nil {
 		return nil, err
 	}
 	defer rawServerTLS.Close()
+	cfg := r.TLSConfig
+	if cfg != nil {
+		cfg = cfg.Clone()
+	} else {
+		cfg = &tls.Config{}
+	}
 	// Ensure that we only advertise HTTP/2 as the accepted protocol.
-	r.TLSConfig.NextProtos = []string{http2.NextProtoTLS}
+	cfg.NextProtos = []string{http2.NextProtoTLS}
+	if cfg.ServerName == "" {
+		cfg.ServerName = serverName
+	}
 	// Initiate TLS and check remote host name against certificate.
-	rawServerTLS = tls.Client(rawServerTLS, r.TLSConfig)
+	rawServerTLS = tls.Client(rawServerTLS, cfg)
 	rawTLSConn, ok := rawServerTLS.(*tls.Conn)
 	if !ok {
 		return nil, errors.New("invalid TLS connection")
@@ -49,8 +62,8 @@ func (r *H2Transport) RoundTrip(_ *http.Request) (*http.Response, error) {
 	if err = rawTLSConn.HandshakeContext(context.Background()); err != nil {
 		return nil, err
 	}
-	if r.TLSConfig == nil || !r.TLSConfig.InsecureSkipVerify {
-		if err = rawTLSConn.VerifyHostname(raddr[:strings.LastIndex(raddr, ":")]); err != nil {
+	if !cfg.InsecureSkipVerify {
+		if err = rawTLSConn.VerifyHostname(serverName); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Hi, we are using goproxy for a sandbox platform that we are building and found this issue that we had to patch in our project, so I asked Codex to help me open this PR:

This fixes an HTTP/2 MITM failure in `H2Transport.RoundTrip()` when the TLS config used for the upstream client connection does not already include `ServerName`.

Before this change, the H2 path could fail with:

`tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config`

The root issue is that `RoundTrip()` reuses `r.TLSConfig` as a client TLS config, but that config is often created for the server-side MITM role and may not yet be valid for upstream client verification.

This change:
- clones the provided TLS config instead of mutating it in place
- restricts ALPN on the cloned config to `h2`
- populates `ServerName` from the upstream host when it is missing
- verifies the hostname against that resolved server name

I hit this while testing Git smart-HTTP over HTTPS with downstream HTTP/2 enabled through the proxy.
