### PR TITLE
http2: do not treat END_STREAM as EOF

### DIFF
--- a/h2.go
+++ b/h2.go
@@ -116,17 +116,13 @@ func proxyFrame(fr *http2.Framer) error {
 		if !ok {
 			return ErrInvalidH2Frame
 		}
-		terr := fr.WriteData(tf.StreamID, tf.StreamEnded(), tf.Data())
-		if terr == nil && tf.StreamEnded() {
-			terr = io.EOF
-		}
-		return terr
+		return fr.WriteData(tf.StreamID, tf.StreamEnded(), tf.Data())
 	case http2.FrameHeaders:
 		tf, ok := f.(*http2.HeadersFrame)
 		if !ok {
 			return ErrInvalidH2Frame
 		}
-		terr := fr.WriteHeaders(http2.HeadersFrameParam{
+		return fr.WriteHeaders(http2.HeadersFrameParam{
 			StreamID:      tf.StreamID,
 			BlockFragment: tf.HeaderBlockFragment(),
 			EndStream:     tf.StreamEnded(),
@@ -134,10 +130,6 @@ func proxyFrame(fr *http2.Framer) error {
 			PadLength:     0,
 			Priority:      tf.Priority,
 		})
-		if terr == nil && tf.StreamEnded() {
-			terr = io.EOF
-		}
-		return terr
 	case http2.FrameContinuation:
 		tf, ok := f.(*http2.ContinuationFrame)
 		if !ok {


### PR DESCRIPTION
Hi, we are using goproxy for a sandbox platform that we are building and found this issue that we had to patch in our project, so I asked Codex to help me open this PR:

This fixes HTTP/2 session teardown in `H2Transport`.

Today `proxyFrame()` returns `io.EOF` when forwarding `DATA` or `HEADERS` frames that carry `END_STREAM`. In HTTP/2 that flag means the stream is complete, not that the entire connection is complete.

Because `H2Transport.RoundTrip()` stops the proxy loop on `io.EOF`, the current behavior can tear down the proxied H2 session after the first completed stream. In my repro this showed up as:
- first stream succeeds
- second stream on the reused connection fails
- client reconnects and retries on a fresh connection

This change forwards `END_STREAM` frames normally and keeps the HTTP/2 session alive for later streams.

I hit this while testing Git smart-HTTP over HTTPS with downstream HTTP/2 enabled through the proxy.
