### PR TITLE
http2: add a generic MITM header rewrite hook

### DIFF
--- a/h2.go
+++ b/h2.go
@@ -2,6 +2,7 @@ package goproxy
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -11,6 +12,7 @@ import (
 	"strings"
 
 	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
 )
 
 var ErrInvalidH2Frame = errors.New("invalid H2 frame")
@@ -19,10 +21,26 @@ var ErrInvalidH2Frame = errors.New("invalid H2 frame")
 // HTTP/2 session, sending all client frames to the server and responses back
 // to the client.
 type H2Transport struct {
-	ClientReader io.Reader
-	ClientWriter io.Writer
-	TLSConfig    *tls.Config
-	Host         string
+	ClientReader   io.Reader
+	ClientWriter   io.Writer
+	TLSConfig      *tls.Config
+	Host           string
+	RewriteHeaders func([]H2HeaderField) []H2HeaderField
+}
+
+// H2HeaderField is a generic, mutable representation of a single HTTP/2
+// header field.
+type H2HeaderField struct {
+	Name      string
+	Value     string
+	Sensitive bool
+}
+
+// H2HeaderRewriter can be optionally implemented by a custom RoundTripper
+// when the downstream MITM path upgrades to HTTP/2 and callers need to
+// mutate decoded request headers before they are forwarded upstream.
+type H2HeaderRewriter interface {
+	RewriteH2HeaderFields([]H2HeaderField) []H2HeaderField
 }
 
 // RoundTrip executes an HTTP/2 session (including all contained streams).
@@ -61,11 +79,12 @@ func (r *H2Transport) RoundTrip(_ *http.Request) (*http.Response, error) {
 	serverTLSReader := bufio.NewReader(rawServerTLS)
 	cToS := http2.NewFramer(rawServerTLS, r.ClientReader)
 	sToC := http2.NewFramer(r.ClientWriter, serverTLSReader)
+	cToSRewriter := newH2HeaderBlockRewriter(r.RewriteHeaders)
 	errSToC := make(chan error)
 	errCToS := make(chan error)
 	go func() {
 		for {
-			if err := proxyFrame(sToC); err != nil {
+			if err := proxyFrame(sToC, nil); err != nil {
 				errSToC <- err
 				break
 			}
@@ -73,7 +92,7 @@ func (r *H2Transport) RoundTrip(_ *http.Request) (*http.Response, error) {
 	}()
 	go func() {
 		for {
-			if err := proxyFrame(cToS); err != nil {
+			if err := proxyFrame(cToS, cToSRewriter); err != nil {
 				errCToS <- err
 				break
 			}
@@ -103,9 +122,36 @@ func dial(network, addr string) (c net.Conn, err error) {
 	return
 }
 
+const maxH2FrameSize = 16384
+
+type h2HeaderBlockRewriter struct {
+	rewrite func([]H2HeaderField) []H2HeaderField
+	decoder *hpack.Decoder
+	fields  []hpack.HeaderField
+	pending *pendingHeaderBlock
+}
+
+type pendingHeaderBlock struct {
+	streamID  uint32
+	endStream bool
+	priority  http2.PriorityParam
+	fragments [][]byte
+}
+
+func newH2HeaderBlockRewriter(rewrite func([]H2HeaderField) []H2HeaderField) *h2HeaderBlockRewriter {
+	if rewrite == nil {
+		return nil
+	}
+	rewriter := &h2HeaderBlockRewriter{rewrite: rewrite}
+	rewriter.decoder = hpack.NewDecoder(4096, func(f hpack.HeaderField) {
+		rewriter.fields = append(rewriter.fields, f)
+	})
+	return rewriter
+}
+
 // proxyFrame reads a single frame from the Framer and, when successful, writes
 // a ~identical one back to the Framer.
-func proxyFrame(fr *http2.Framer) error {
+func proxyFrame(fr *http2.Framer, rewriter *h2HeaderBlockRewriter) error {
 	f, err := fr.ReadFrame()
 	if err != nil {
 		return err
@@ -126,6 +172,9 @@ func proxyFrame(fr *http2.Framer) error {
 		if !ok {
 			return ErrInvalidH2Frame
 		}
+		if rewriter != nil {
+			return rewriter.handleHeaders(fr, tf)
+		}
 		terr := fr.WriteHeaders(http2.HeadersFrameParam{
 			StreamID:      tf.StreamID,
 			BlockFragment: tf.HeaderBlockFragment(),
@@ -142,6 +191,9 @@ func proxyFrame(fr *http2.Framer) error {
 		tf, ok := f.(*http2.ContinuationFrame)
 		if !ok {
 			return ErrInvalidH2Frame
+		}
+		if rewriter != nil {
+			return rewriter.handleContinuation(fr, tf)
 		}
 		return fr.WriteContinuation(tf.StreamID, tf.HeadersEnded(), tf.HeaderBlockFragment())
 	case http2.FrameGoAway:
@@ -205,4 +257,86 @@ func proxyFrame(fr *http2.Framer) error {
 	default:
 		return errors.New("Unsupported frame: " + string(f.Header().Type))
 	}
+}
+
+func (rw *h2HeaderBlockRewriter) handleHeaders(fr *http2.Framer, hf *http2.HeadersFrame) error {
+	if hf.HeadersEnded() {
+		return rw.flush(fr, hf.StreamID, hf.StreamEnded(), hf.Priority, hf.HeaderBlockFragment())
+	}
+	rw.pending = &pendingHeaderBlock{
+		streamID:  hf.StreamID,
+		endStream: hf.StreamEnded(),
+		priority:  hf.Priority,
+		fragments: [][]byte{append([]byte(nil), hf.HeaderBlockFragment()...)},
+	}
+	return nil
+}
+
+func (rw *h2HeaderBlockRewriter) handleContinuation(fr *http2.Framer, cf *http2.ContinuationFrame) error {
+	if rw.pending == nil || rw.pending.streamID != cf.StreamID {
+		return ErrInvalidH2Frame
+	}
+	rw.pending.fragments = append(rw.pending.fragments, append([]byte(nil), cf.HeaderBlockFragment()...))
+	if !cf.HeadersEnded() {
+		return nil
+	}
+	var block []byte
+	for _, fragment := range rw.pending.fragments {
+		block = append(block, fragment...)
+	}
+	pending := rw.pending
+	rw.pending = nil
+	return rw.flush(fr, pending.streamID, pending.endStream, pending.priority, block)
+}
+
+func (rw *h2HeaderBlockRewriter) flush(fr *http2.Framer, streamID uint32, endStream bool, priority http2.PriorityParam, block []byte) error {
+	rw.fields = nil
+	if _, err := rw.decoder.Write(block); err != nil {
+		return err
+	}
+	if err := rw.decoder.Close(); err != nil {
+		return err
+	}
+	fields := make([]H2HeaderField, 0, len(rw.fields))
+	for _, field := range rw.fields {
+		fields = append(fields, H2HeaderField{Name: field.Name, Value: field.Value, Sensitive: field.Sensitive})
+	}
+	fields = rw.rewrite(fields)
+	var encoded bytes.Buffer
+	encoder := hpack.NewEncoder(&encoded)
+	for _, field := range fields {
+		if err := encoder.WriteField(hpack.HeaderField{Name: field.Name, Value: field.Value, Sensitive: field.Sensitive}); err != nil {
+			return err
+		}
+	}
+	return writeHeaderBlock(fr, streamID, endStream, priority, encoded.Bytes())
+}
+
+func writeHeaderBlock(fr *http2.Framer, streamID uint32, endStream bool, priority http2.PriorityParam, block []byte) error {
+	if len(block) <= maxH2FrameSize {
+		return fr.WriteHeaders(http2.HeadersFrameParam{
+			StreamID:      streamID,
+			BlockFragment: block,
+			EndStream:     endStream,
+			EndHeaders:    true,
+			Priority:      priority,
+		})
+	}
+	if err := fr.WriteHeaders(http2.HeadersFrameParam{
+		StreamID:      streamID,
+		BlockFragment: block[:maxH2FrameSize],
+		EndStream:     endStream,
+		EndHeaders:    false,
+		Priority:      priority,
+	}); err != nil {
+		return err
+	}
+	block = block[maxH2FrameSize:]
+	for len(block) > maxH2FrameSize {
+		if err := fr.WriteContinuation(streamID, false, block[:maxH2FrameSize]); err != nil {
+			return err
+		}
+		block = block[maxH2FrameSize:]
+	}
+	return fr.WriteContinuation(streamID, true, block)
 }

--- a/h2_test.go
+++ b/h2_test.go
@@ -1,0 +1,109 @@
+package goproxy
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/hpack"
+)
+
+func TestProxyFrameRewritesHeaders(t *testing.T) {
+	var input bytes.Buffer
+	block := encodeHeaderBlock(t,
+		H2HeaderField{Name: ":method", Value: "GET"},
+		H2HeaderField{Name: "authorization", Value: "Basic old", Sensitive: true},
+	)
+	inputFramer := http2.NewFramer(&input, nil)
+	if err := inputFramer.WriteHeaders(http2.HeadersFrameParam{
+		StreamID:      1,
+		BlockFragment: block,
+		EndHeaders:    true,
+		EndStream:     true,
+	}); err != nil {
+		t.Fatalf("write input headers: %v", err)
+	}
+
+	var output bytes.Buffer
+	fr := http2.NewFramer(&output, bytes.NewReader(input.Bytes()))
+	rewriter := newH2HeaderBlockRewriter(func(fields []H2HeaderField) []H2HeaderField {
+		out := append([]H2HeaderField(nil), fields...)
+		for i := range out {
+			if out[i].Name == "authorization" {
+				out[i].Value = "Basic new"
+			}
+		}
+		return out
+	})
+	if err := proxyFrame(fr, rewriter); err != nil && err != io.EOF {
+		t.Fatalf("proxy frame: %v", err)
+	}
+
+	fields := readHeaderBlock(t, output.Bytes())
+	if got := headerValue(fields, "authorization"); got != "Basic new" {
+		t.Fatalf("authorization mismatch: got %q", got)
+	}
+}
+
+func encodeHeaderBlock(t *testing.T, fields ...H2HeaderField) []byte {
+	t.Helper()
+	var block bytes.Buffer
+	enc := hpack.NewEncoder(&block)
+	for _, field := range fields {
+		if err := enc.WriteField(hpack.HeaderField{Name: field.Name, Value: field.Value, Sensitive: field.Sensitive}); err != nil {
+			t.Fatalf("encode header %q: %v", field.Name, err)
+		}
+	}
+	return block.Bytes()
+}
+
+func readHeaderBlock(t *testing.T, data []byte) []H2HeaderField {
+	t.Helper()
+	fr := http2.NewFramer(io.Discard, bytes.NewReader(data))
+	var block bytes.Buffer
+	for {
+		frame, err := fr.ReadFrame()
+		if err != nil {
+			t.Fatalf("read output frame: %v", err)
+		}
+		switch f := frame.(type) {
+		case *http2.HeadersFrame:
+			block.Write(f.HeaderBlockFragment())
+			if f.HeadersEnded() {
+				return decodeHeaderBlock(t, block.Bytes())
+			}
+		case *http2.ContinuationFrame:
+			block.Write(f.HeaderBlockFragment())
+			if f.HeadersEnded() {
+				return decodeHeaderBlock(t, block.Bytes())
+			}
+		default:
+			t.Fatalf("unexpected frame type %T", f)
+		}
+	}
+}
+
+func decodeHeaderBlock(t *testing.T, block []byte) []H2HeaderField {
+	t.Helper()
+	var fields []H2HeaderField
+	decoder := hpack.NewDecoder(4096, func(field hpack.HeaderField) {
+		fields = append(fields, H2HeaderField{Name: field.Name, Value: field.Value, Sensitive: field.Sensitive})
+	})
+	if _, err := decoder.Write(block); err != nil {
+		t.Fatalf("decode block write: %v", err)
+	}
+	if err := decoder.Close(); err != nil {
+		t.Fatalf("decode block close: %v", err)
+	}
+	return fields
+}
+
+func headerValue(fields []H2HeaderField, name string) string {
+	for _, field := range fields {
+		if field.Name == name {
+			return field.Value
+		}
+	}
+	return ""
+}

--- a/https.go
+++ b/https.go
@@ -308,7 +308,10 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 								ctx.Warnf("HTTP2 connection failed: disallowed")
 								return false
 							}
-							tr := H2Transport{reader, client, tlsConfig, host}
+							tr := H2Transport{ClientReader: reader, ClientWriter: client, TLSConfig: tlsConfig, Host: host}
+							if rewriter, ok := ctx.RoundTripper.(H2HeaderRewriter); ok {
+								tr.RewriteHeaders = rewriter.RewriteH2HeaderFields
+							}
 							if _, err := tr.RoundTrip(req); err != nil {
 								ctx.Warnf("HTTP2 connection failed: %v", err)
 							} else {


### PR DESCRIPTION
## Summary
- add a generic HTTP/2 request header rewrite hook for the MITM path
- wire the hook from the existing `ctx.RoundTripper` customization surface
- add a focused unit test covering HPACK decode/rewrite/re-encode for request headers

## Why
The downstream HTTP/2 MITM path currently raw-proxies HEADERS frames, so callers can customize HTTP/1.1 MITM requests but cannot apply equivalent header mutation to HTTP/2 requests.

This adds a small generic extension point:
- `H2HeaderField`
- `H2HeaderRewriter`
- `H2Transport.RewriteHeaders`

When a custom `ctx.RoundTripper` also implements `H2HeaderRewriter`, the HTTP/2 MITM path decodes the client->server HPACK header block, lets the caller mutate it, then re-encodes and forwards it upstream.

Closes #766.

## Testing
- `go test ./...`
