### PR TITLE
docs: add missing godoc comments to exported symbols

### DIFF
--- a/certs.go
+++ b/certs.go
@@ -5,6 +5,10 @@ import (
 	"crypto/x509"
 )
 
+// GoproxyCa is the built-in self-signed CA certificate used by default for MITM interception.
+// It is loaded at package initialization from CA_CERT and CA_KEY.
+// You can replace it with your own CA by calling TLSConfigFromCA with a different certificate
+// and assigning the result to ConnectAction.TLSConfig.
 var GoproxyCa tls.Certificate
 
 func init() {
@@ -29,6 +33,10 @@ var defaultTLSConfig = &tls.Config{
 	InsecureSkipVerify: true,
 }
 
+// CA_CERT is the PEM-encoded certificate of the built-in proxy CA.
+// It is used together with CA_KEY to initialize GoproxyCa at startup.
+// Expose it to clients so they can import and trust the proxy CA,
+// which is required to avoid TLS errors during MITM interception.
 var CA_CERT = []byte(`-----BEGIN CERTIFICATE-----
 MIIF9DCCA9ygAwIBAgIJAODqYUwoVjJkMA0GCSqGSIb3DQEBCwUAMIGOMQswCQYD
 VQQGEwJJTDEPMA0GA1UECAwGQ2VudGVyMQwwCgYDVQQHDANMb2QxEDAOBgNVBAoM
@@ -64,6 +72,8 @@ NCNwK5Yl6HuvF97CIH5CdgO+5C7KifUtqTOL8pQKbNwy0S3sNYvB+njGvRpR7pKV
 BUnFpB/Atptqr4CUlTXrc5IPLAqAfmwk5IKcwy3EXUbruf9Dwz69YA==
 -----END CERTIFICATE-----`)
 
+// CA_KEY is the PEM-encoded RSA private key of the built-in proxy CA.
+// It is used together with CA_CERT to initialize GoproxyCa at startup.
 var CA_KEY = []byte(`-----BEGIN RSA PRIVATE KEY-----
 MIIJKAIBAAKCAgEAnhDL4fqGGhjWzRBFy8iHGuNIdo79FtoWPevCpyek6AWrTuBF
 0j3dzRMUpAkemC/p94tGES9f9iWUVi7gnfmUz1lxhjiqUoW5K1xfwmbx+qmC2YAw

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -294,6 +294,11 @@ func (pcond *ReqProxyConds) HandleConnectFunc(f func(host string, ctx *ProxyCtx)
 	pcond.HandleConnect(FuncHttpsHandler(f))
 }
 
+// HijackConnect registers a handler that takes full control of the raw net.Conn
+// for CONNECT requests that match the aggregated conditions.
+// The handler receives the original HTTP request, the raw client connection, and the proxy context.
+// It is the handler's responsibility to write an HTTP response (e.g. "HTTP/1.1 200 OK\r\n\r\n")
+// and close the connection when done.
 func (pcond *ReqProxyConds) HijackConnect(f func(req *http.Request, client net.Conn, ctx *ProxyCtx)) {
 	pcond.proxy.httpsHandlers = append(pcond.proxy.httpsHandlers,
 		FuncHttpsHandler(func(host string, ctx *ProxyCtx) (*ConnectAction, string) {

--- a/https.go
+++ b/https.go
@@ -19,24 +19,58 @@ import (
 	"github.com/elazarl/goproxy/internal/signer"
 )
 
+// ConnectActionLiteral defines the action the proxy should take
+// when it receives an HTTP CONNECT request from a client.
 type ConnectActionLiteral int
 
 const (
-	ConnectAccept = iota
+	// ConnectAccept instructs the proxy to accept the CONNECT request
+	// and establish a transparent TCP tunnel to the destination host.
+	// The proxy will forward raw bytes in both directions without inspecting them.
+	ConnectAccept ConnectActionLiteral = iota
+
+	// ConnectReject instructs the proxy to reject the CONNECT request
+	// and immediately close the connection with the client.
 	ConnectReject
+
+	// ConnectMitm instructs the proxy to perform a Man-in-the-Middle (MITM)
+	// attack on the CONNECT tunnel. The proxy generates a dynamic TLS certificate
+	// for the target host, signed by its CA (see GoproxyCa), and establishes
+	// separate TLS connections with both the client and the destination server.
+	// All request and response handlers remain active on this intercepted connection.
 	ConnectMitm
+
+	// ConnectHijack instructs the proxy to hand the raw net.Conn to the function
+	// defined in ConnectAction.Hijack, giving full low-level control of the
+	// connection to the caller. The hijack function is responsible for sending
+	// an HTTP response (e.g. "HTTP/1.1 200 OK") back to the client.
 	ConnectHijack
-	// Deprecated: use ConnectMitm.
+
+	// ConnectHTTPMitm is deprecated: use ConnectMitm instead.
 	ConnectHTTPMitm
+
+	// ConnectProxyAuthHijack instructs the proxy to hijack the CONNECT connection
+	// after a proxy authentication failure, allowing the handler to send
+	// a custom authentication challenge or error response to the client.
 	ConnectProxyAuthHijack
 )
 
 var (
-	OkConnect   = &ConnectAction{Action: ConnectAccept, TLSConfig: TLSConfigFromCA(&GoproxyCa)}
+	// OkConnect is a ready-to-use ConnectAction that accepts the CONNECT request
+	// and creates a transparent TCP tunnel to the destination host, using the built-in CA.
+	OkConnect = &ConnectAction{Action: ConnectAccept, TLSConfig: TLSConfigFromCA(&GoproxyCa)}
+
+	// MitmConnect is a ready-to-use ConnectAction that performs MITM interception,
+	// signing dynamic TLS certificates with the built-in CA (GoproxyCa).
+	// Use proxy.CertStore to cache generated certificates and save CPU in production.
 	MitmConnect = &ConnectAction{Action: ConnectMitm, TLSConfig: TLSConfigFromCA(&GoproxyCa)}
-	// Deprecated: use MitmConnect.
+
+	// HTTPMitmConnect is deprecated: use MitmConnect instead.
 	HTTPMitmConnect = &ConnectAction{Action: ConnectHTTPMitm, TLSConfig: TLSConfigFromCA(&GoproxyCa)}
-	RejectConnect   = &ConnectAction{Action: ConnectReject, TLSConfig: TLSConfigFromCA(&GoproxyCa)}
+
+	// RejectConnect is a ready-to-use ConnectAction that rejects the CONNECT request
+	// and closes the connection with the client.
+	RejectConnect = &ConnectAction{Action: ConnectReject, TLSConfig: TLSConfigFromCA(&GoproxyCa)}
 )
 
 var _errorRespMaxLength int64 = 500
@@ -458,10 +492,19 @@ func dialerFromEnv(proxy *ProxyHttpServer) func(network, addr string) (net.Conn,
 	return proxy.NewConnectDialToProxy(httpsProxy)
 }
 
+// NewConnectDialToProxy returns a dial function that establishes TCP connections
+// through an upstream HTTP/HTTPS proxy using the CONNECT method.
+// Use it to set proxy.ConnectDial when chaining two proxy servers.
+// For authentication or other CONNECT request modifications, use NewConnectDialToProxyWithHandler instead.
 func (proxy *ProxyHttpServer) NewConnectDialToProxy(httpsProxy string) func(network, addr string) (net.Conn, error) {
 	return proxy.NewConnectDialToProxyWithHandler(httpsProxy, nil)
 }
 
+// NewConnectDialToProxyWithHandler returns a dial function that establishes TCP connections
+// through an upstream HTTP/HTTPS proxy using the CONNECT method, calling connectReqHandler
+// before sending the CONNECT request. Use connectReqHandler to add headers such as
+// Proxy-Authorization to authenticate with the upstream proxy.
+// If connectReqHandler is nil, the behavior is identical to NewConnectDialToProxy.
 func (proxy *ProxyHttpServer) NewConnectDialToProxyWithHandler(
 	httpsProxy string,
 	connectReqHandler func(req *http.Request),
@@ -560,6 +603,10 @@ func (proxy *ProxyHttpServer) NewConnectDialToProxyWithHandler(
 	return nil
 }
 
+// TLSConfigFromCA returns a TLSConfig function that generates dynamic TLS certificates
+// for each target host, signed by the given CA certificate.
+// The generated certificates are used during MITM interception (ConnectMitm).
+// If a CertStorage is set on the ProxyCtx, certificates are cached and reused to save CPU.
 func TLSConfigFromCA(ca *tls.Certificate) func(host string, ctx *ProxyCtx) (*tls.Config, error) {
 	return func(host string, ctx *ProxyCtx) (*tls.Config, error) {
 		var err error

--- a/logger.go
+++ b/logger.go
@@ -1,5 +1,9 @@
 package goproxy
 
+// Logger is the interface used by ProxyHttpServer to emit log messages.
+// Any type implementing Printf with the standard fmt.Sprintf signature satisfies this interface.
+// By default, NewProxyHttpServer sets Logger to log.New(os.Stderr, "", log.LstdFlags).
+// Log output is emitted only when ProxyHttpServer.Verbose is set to true.
 type Logger interface {
 	Printf(format string, v ...any)
 }

--- a/proxy.go
+++ b/proxy.go
@@ -17,13 +17,21 @@ type ProxyHttpServer struct {
 	// KeepDestinationHeaders indicates the proxy should retain any headers present in the http.Response before proxying
 	KeepDestinationHeaders bool
 	// setting Verbose to true will log information on each request sent to the proxy
-	Verbose         bool
-	Logger          Logger
+	Verbose bool
+	// Logger is used to emit log messages. Defaults to log.New(os.Stderr, "", log.LstdFlags).
+	// Log output is only produced when Verbose is true.
+	// Any type implementing Printf satisfies the Logger interface.
+	Logger Logger
+	// NonproxyHandler is invoked for requests that are not proxy requests,
+	// i.e. requests with a relative path (e.g. GET /ping) instead of an absolute URL.
+	// Defaults to a handler that returns HTTP 500 with an explanatory message.
 	NonproxyHandler http.Handler
 	reqHandlers     []ReqHandler
 	respHandlers    []RespHandler
 	httpsHandlers   []HttpsHandler
-	Tr              *http.Transport
+	// Tr is the http.Transport used to send requests to destination servers.
+	// Defaults to a transport that skips TLS verification and reads proxy settings from environment variables.
+	Tr *http.Transport
 	// ConnectionErrHandler will be invoked to return a custom response
 	// to clients (written using conn parameter), when goproxy fails to connect
 	// to a target proxy.
@@ -32,11 +40,20 @@ type ProxyHttpServer struct {
 	ConnectionErrHandler func(conn io.Writer, ctx *ProxyCtx, err error)
 	// ConnectDial will be used to create TCP connections for CONNECT requests
 	// if nil Tr.Dial will be used
-	ConnectDial        func(network string, addr string) (net.Conn, error)
+	ConnectDial func(network string, addr string) (net.Conn, error)
+	// ConnectDialWithReq is like ConnectDial but also receives the original CONNECT request,
+	// allowing dial decisions based on request headers (e.g. target host, auth tokens).
+	// When both ConnectDialWithReq and ConnectDial are set, ConnectDialWithReq takes precedence.
 	ConnectDialWithReq func(req *http.Request, network string, addr string) (net.Conn, error)
-	CertStore          CertStorage
-	KeepHeader         bool
-	AllowHTTP2         bool
+	// CertStore is an optional cache for MITM certificates. When set, the proxy reuses
+	// previously generated TLS certificates for the same hostname, avoiding repeated
+	// CPU-intensive signing operations. Strongly recommended for production use.
+	CertStore CertStorage
+	// KeepHeader, when true, preserves the Proxy-Authorization header when forwarding
+	// requests to an upstream proxy. By default this header is stripped.
+	KeepHeader bool
+	// AllowHTTP2, when true, enables HTTP/2 support in the proxy. Disabled by default.
+	AllowHTTP2 bool
 	// When PreventCanonicalization is true, the header names present in
 	// the request sent through the proxy are directly passed to the destination server,
 	// instead of following the HTTP RFC for their canonicalization.

--- a/responses.go
+++ b/responses.go
@@ -32,7 +32,9 @@ func NewResponse(r *http.Request, contentType string, status int, body string) *
 }
 
 const (
+	// ContentTypeText is the MIME type for plain text responses.
 	ContentTypeText = "text/plain"
+	// ContentTypeHtml is the MIME type for HTML responses.
 	ContentTypeHtml = "text/html"
 )
 


### PR DESCRIPTION
- Document ConnectActionLiteral type and all its constants (ConnectAccept, ConnectReject, ConnectMitm, ConnectHijack, ConnectProxyAuthHijack)
- Document OkConnect, MitmConnect, RejectConnect, HTTPMitmConnect vars
- Document TLSConfigFromCA, NewConnectDialToProxy, NewConnectDialToProxyWithHandler methods
- Document HijackConnect method in ReqProxyConds
- Document Logger interface
- Document GoproxyCa, CA_CERT, CA_KEY exported vars
- Document ContentTypeText and ContentTypeHtml constants
- Review and complete ProxyHttpServer field comments (Logger, NonproxyHandler, Tr, ConnectDialWithReq, CertStore, KeepHeader, AllowHTTP2)

Closes #629
Closes #364