### PR TITLE
Emit declared response trailers

### DIFF
--- a/http.go
+++ b/http.go
@@ -58,10 +58,16 @@ func (proxy *ProxyHttpServer) handleHttp(w http.ResponseWriter, r *http.Request)
 	// We keep the original body to remove the header only if things changed.
 	// This will prevent problems with HEAD requests where there's no body, yet,
 	// the Content-Length header should be set.
-	if origBody != resp.Body {
+	announcedTrailers := declaredTrailers(resp)
+	if origBody != resp.Body || len(announcedTrailers) > 0 {
 		resp.Header.Del("Content-Length")
 	}
 	copyHeaders(w.Header(), resp.Header, proxy.KeepDestinationHeaders)
+	for trailer := range announcedTrailers {
+		if !headerDeclaresTrailer(resp.Header, trailer) {
+			w.Header().Add("Trailer", trailer)
+		}
+	}
 	w.WriteHeader(resp.StatusCode)
 
 	if isWebSocketHandshake(resp.Header) {
@@ -93,5 +99,51 @@ func (proxy *ProxyHttpServer) handleHttp(w http.ResponseWriter, r *http.Request)
 	if err := resp.Body.Close(); err != nil {
 		ctx.Warnf("Can't close response body %v", err)
 	}
+	if len(resp.Trailer) > 0 {
+		_ = http.NewResponseController(w).Flush()
+		writeTrailers(w.Header(), resp.Trailer, announcedTrailers)
+	}
 	ctx.Logf("Copied %v bytes to client error=%v", nr, err)
+}
+
+func declaredTrailers(resp *http.Response) map[string]struct{} {
+	trailers := map[string]struct{}{}
+	for trailer := range declaredTrailersFromHeader(resp.Header) {
+		trailers[trailer] = struct{}{}
+	}
+	for trailer := range resp.Trailer {
+		trailers[http.CanonicalHeaderKey(trailer)] = struct{}{}
+	}
+	return trailers
+}
+
+func declaredTrailersFromHeader(header http.Header) map[string]struct{} {
+	trailers := map[string]struct{}{}
+	for _, headerValue := range header.Values("Trailer") {
+		for _, trailer := range strings.Split(headerValue, ",") {
+			trailer = http.CanonicalHeaderKey(strings.TrimSpace(trailer))
+			if trailer == "" {
+				continue
+			}
+			trailers[trailer] = struct{}{}
+		}
+	}
+	return trailers
+}
+
+func headerDeclaresTrailer(header http.Header, trailer string) bool {
+	_, ok := declaredTrailersFromHeader(header)[http.CanonicalHeaderKey(trailer)]
+	return ok
+}
+
+func writeTrailers(dst, trailers http.Header, announced map[string]struct{}) {
+	for trailer, values := range trailers {
+		key := http.CanonicalHeaderKey(trailer)
+		if _, ok := announced[key]; !ok {
+			key = http.TrailerPrefix + key
+		}
+		for _, value := range values {
+			dst.Add(key, value)
+		}
+	}
 }

--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,68 @@
+package goproxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type lateTrailerBody struct {
+	io.ReadCloser
+	onClose func()
+}
+
+func (b *lateTrailerBody) Close() error {
+	if b.onClose != nil {
+		b.onClose()
+		b.onClose = nil
+	}
+	return b.ReadCloser.Close()
+}
+
+func TestHandleHTTPWritesDeclaredTrailers(t *testing.T) {
+	proxy := NewProxyHttpServer()
+	proxy.OnRequest().DoFunc(func(r *http.Request, _ *ProxyCtx) (*http.Request, *http.Response) {
+		trailer := http.Header{}
+		body := &lateTrailerBody{
+			ReadCloser: io.NopCloser(strings.NewReader("hello")),
+			onClose: func() {
+				trailer.Add("Server-Timing", "server_read;dur=1")
+			},
+		}
+
+		return r, &http.Response{
+			Status:        "200 OK",
+			StatusCode:    http.StatusOK,
+			Header:        http.Header{"Content-Length": []string{"5"}, "Content-Type": []string{"text/plain"}, "Trailer": []string{"Server-Timing"}},
+			Trailer:       trailer,
+			Body:          body,
+			ContentLength: 5,
+			Request:       r,
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/trailers", nil)
+	rec := httptest.NewRecorder()
+	proxy.ServeHTTP(rec, req)
+
+	resp := rec.Result()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("close response body: %v", err)
+	}
+
+	if got := string(body); got != "hello" {
+		t.Fatalf("unexpected body %q", got)
+	}
+	if got := resp.Trailer.Get("Server-Timing"); got != "server_read;dur=1" {
+		t.Fatalf("unexpected trailer %q", got)
+	}
+	if resp.ContentLength != -1 {
+		t.Fatalf("expected chunked response for trailers, got content length %d", resp.ContentLength)
+	}
+}


### PR DESCRIPTION
> prompted codex into fixing this, the fix looks good to me, but open to feedback :)

## Problem 


`handleHttp` was forwarding the `Trailer` header declaration but never writing the trailer values onto the downstream `http.ResponseWriter`.

That meant clients could see `Trailer: Server-Timing` in the response headers, but the actual trailing `Server-Timing` fields were never sent.

## What this PR does

This updates the HTTP response write path to actually emit declared response trailers to downstream clients.

- drop `Content-Length` when trailers are declared so HTTP/1.1 can use chunked framing (otherwise no trailers are expected after `Content-Length` number of bytes). 
  - HTTP/2 doesn't have behave like this and this change means that even for HTTP/2 we use chunked when there are trailers and we would have otherwise used regular encoding
- copy `resp.Trailer` onto the downstream `ResponseWriter` after the body finishes streaming
