### PR TITLE
fix: append headers instead of overwriting when keepDestHeaders is true

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -62,8 +62,14 @@ func copyHeaders(dst, src http.Header, keepDestHeaders bool) {
 		}
 	}
 	for k, vs := range src {
-		// direct assignment to avoid canonicalization
-		dst[k] = append([]string(nil), vs...)
+		if keepDestHeaders {
+			// Append to existing values to preserve non-unique headers
+			// like Set-Cookie.
+			dst[k] = append(dst[k], vs...)
+		} else {
+			// direct assignment to avoid canonicalization
+			dst[k] = append([]string(nil), vs...)
+		}
 	}
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -58,17 +58,13 @@ var hasPort = regexp.MustCompile(`:\d+$`)
 func copyHeaders(dst, src http.Header, keepDestHeaders bool) {
 	if !keepDestHeaders {
 		for k := range dst {
-			dst.Del(k)
+			delete(dst, k)
 		}
 	}
 	for k, vs := range src {
 		if keepDestHeaders {
-			// Append to existing values to preserve non-unique headers
-			// like Set-Cookie.
-			dst[k] = append(dst[k], vs...)
-		} else {
 			// direct assignment to avoid canonicalization
-			dst[k] = append([]string(nil), vs...)
+			dst[k] = append(dst[k], vs...)
 		}
 	}
 }

--- a/proxy.go
+++ b/proxy.go
@@ -62,10 +62,8 @@ func copyHeaders(dst, src http.Header, keepDestHeaders bool) {
 		}
 	}
 	for k, vs := range src {
-		if keepDestHeaders {
-			// direct assignment to avoid canonicalization
-			dst[k] = append(dst[k], vs...)
-		}
+		// direct assignment to avoid canonicalization
+		dst[k] = append(dst[k], vs...)
 	}
 }
 


### PR DESCRIPTION
Fixes #752

## Problem

`copyHeaders` with `keepDestHeaders=true` overwrites destination header values instead of appending:

```go
dst[k] = append([]string(nil), vs...)
```

This drops all original destination values for non-unique headers like `Set-Cookie`. When a backend adds its own `Set-Cookie` header and the proxy response handler has already set a different `Set-Cookie`, the original is lost.

## Fix

When `keepDestHeaders` is true, append source values to existing destination values:

```go
if keepDestHeaders {
    dst[k] = append(dst[k], vs...)
} else {
    dst[k] = append([]string(nil), vs...)
}
```

This preserves all existing destination headers while adding source headers, correctly handling multi-value headers like `Set-Cookie`.