### PR TITLE
h2: terminate HTTP/2 sessions instead of forwarding raw frames

### DIFF
--- a/h2.go
+++ b/h2.go
@@ -1,208 +1,68 @@
 package goproxy
 
 import (
-	"bufio"
-	"context"
-	"crypto/tls"
-	"errors"
 	"io"
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"golang.org/x/net/http2"
 )
 
-var ErrInvalidH2Frame = errors.New("invalid H2 frame")
-
-// H2Transport is an implementation of RoundTripper that abstracts an entire
-// HTTP/2 session, sending all client frames to the server and responses back
-// to the client.
-type H2Transport struct {
-	ClientReader io.Reader
-	ClientWriter io.Writer
-	TLSConfig    *tls.Config
-	Host         string
+// h2Conn adapts an io.Reader/io.Writer pair into a net.Conn for
+// http2.Server.ServeConn.
+type h2Conn struct {
+	r    io.Reader
+	w    io.Writer
+	conn net.Conn
 }
 
-// RoundTrip executes an HTTP/2 session (including all contained streams).
-// The request and response are ignored but any error encountered during the
-// proxying from the session is returned as a result of the invocation.
-func (r *H2Transport) RoundTrip(_ *http.Request) (*http.Response, error) {
-	raddr := r.Host
-	if !strings.Contains(raddr, ":") {
-		raddr += ":443"
-	}
-	rawServerTLS, err := dial("tcp", raddr)
-	if err != nil {
-		return nil, err
-	}
-	defer rawServerTLS.Close()
-	// Ensure that we only advertise HTTP/2 as the accepted protocol.
-	r.TLSConfig.NextProtos = []string{http2.NextProtoTLS}
-	// Initiate TLS and check remote host name against certificate.
-	rawServerTLS = tls.Client(rawServerTLS, r.TLSConfig)
-	rawTLSConn, ok := rawServerTLS.(*tls.Conn)
-	if !ok {
-		return nil, errors.New("invalid TLS connection")
-	}
-	if err = rawTLSConn.HandshakeContext(context.Background()); err != nil {
-		return nil, err
-	}
-	if r.TLSConfig == nil || !r.TLSConfig.InsecureSkipVerify {
-		if err = rawTLSConn.VerifyHostname(raddr[:strings.LastIndex(raddr, ":")]); err != nil {
-			return nil, err
-		}
-	}
-	// Send new client preface to match the one parsed in req.
-	if _, err := io.WriteString(rawServerTLS, http2.ClientPreface); err != nil {
-		return nil, err
-	}
-	serverTLSReader := bufio.NewReader(rawServerTLS)
-	cToS := http2.NewFramer(rawServerTLS, r.ClientReader)
-	sToC := http2.NewFramer(r.ClientWriter, serverTLSReader)
-	errSToC := make(chan error)
-	errCToS := make(chan error)
-	go func() {
-		for {
-			if err := proxyFrame(sToC); err != nil {
-				errSToC <- err
-				break
-			}
-		}
-	}()
-	go func() {
-		for {
-			if err := proxyFrame(cToS); err != nil {
-				errCToS <- err
-				break
-			}
-		}
-	}()
-	for i := 0; i < 2; i++ {
-		select {
-		case err := <-errSToC:
-			if !errors.Is(err, io.EOF) {
-				return nil, err
-			}
-		case err := <-errCToS:
-			if !errors.Is(err, io.EOF) {
-				return nil, err
-			}
-		}
-	}
-	return nil, nil
+func (c *h2Conn) Read(p []byte) (int, error)        { return c.r.Read(p) }
+func (c *h2Conn) Write(p []byte) (int, error)       { return c.w.Write(p) }
+func (c *h2Conn) Close() error                      { return c.conn.Close() }
+func (c *h2Conn) LocalAddr() net.Addr               { return c.conn.LocalAddr() }
+func (c *h2Conn) RemoteAddr() net.Addr              { return c.conn.RemoteAddr() }
+func (c *h2Conn) SetDeadline(t time.Time) error     { return c.conn.SetDeadline(t) }
+func (c *h2Conn) SetReadDeadline(t time.Time) error { return c.conn.SetReadDeadline(t) }
+func (c *h2Conn) SetWriteDeadline(t time.Time) error {
+	return c.conn.SetWriteDeadline(t)
 }
 
-func dial(network, addr string) (c net.Conn, err error) {
-	addri, err := net.ResolveTCPAddr(network, addr)
-	if err != nil {
-		return
-	}
-	c, err = net.DialTCP(network, nil, addri)
-	return
-}
+// serveH2 terminates an HTTP/2 client session on the already-decrypted
+// conn, decoding each stream into a standard *http.Request and handing it
+// to the proxy's normal HTTP handler (filterRequest → RoundTrip →
+// filterResponse). The caller must have already consumed the HTTP/2
+// client preface ("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n").
+//
+// remoteAddr is the original client address (typically from the outer
+// CONNECT request) and is propagated to each decoded *http.Request so
+// downstream handlers see the real client rather than an intermediate.
+//
+// parentCtx, if non-nil, supplies UserData and RoundTripper that should
+// be inherited by every per-stream ProxyCtx — matching the behaviour of
+// the HTTP/1.1 path in handleHttps.
+func (proxy *ProxyHttpServer) serveH2(clientReader io.Reader, clientConn net.Conn, host, remoteAddr string, parentCtx *ProxyCtx) {
+	// Prepend the client preface so http2.Server.ServeConn can read it.
+	preface := io.MultiReader(strings.NewReader(http2.ClientPreface), clientReader)
+	conn := &h2Conn{r: preface, w: clientConn, conn: clientConn}
 
-// proxyFrame reads a single frame from the Framer and, when successful, writes
-// a ~identical one back to the Framer.
-func proxyFrame(fr *http2.Framer) error {
-	f, err := fr.ReadFrame()
-	if err != nil {
-		return err
-	}
-	switch f.Header().Type {
-	case http2.FrameData:
-		tf, ok := f.(*http2.DataFrame)
-		if !ok {
-			return ErrInvalidH2Frame
-		}
-		terr := fr.WriteData(tf.StreamID, tf.StreamEnded(), tf.Data())
-		if terr == nil && tf.StreamEnded() {
-			terr = io.EOF
-		}
-		return terr
-	case http2.FrameHeaders:
-		tf, ok := f.(*http2.HeadersFrame)
-		if !ok {
-			return ErrInvalidH2Frame
-		}
-		terr := fr.WriteHeaders(http2.HeadersFrameParam{
-			StreamID:      tf.StreamID,
-			BlockFragment: tf.HeaderBlockFragment(),
-			EndStream:     tf.StreamEnded(),
-			EndHeaders:    tf.HeadersEnded(),
-			PadLength:     0,
-			Priority:      tf.Priority,
-		})
-		if terr == nil && tf.StreamEnded() {
-			terr = io.EOF
-		}
-		return terr
-	case http2.FrameContinuation:
-		tf, ok := f.(*http2.ContinuationFrame)
-		if !ok {
-			return ErrInvalidH2Frame
-		}
-		return fr.WriteContinuation(tf.StreamID, tf.HeadersEnded(), tf.HeaderBlockFragment())
-	case http2.FrameGoAway:
-		tf, ok := f.(*http2.GoAwayFrame)
-		if !ok {
-			return ErrInvalidH2Frame
-		}
-		return fr.WriteGoAway(tf.StreamID, tf.ErrCode, tf.DebugData())
-	case http2.FramePing:
-		tf, ok := f.(*http2.PingFrame)
-		if !ok {
-			return ErrInvalidH2Frame
-		}
-		return fr.WritePing(tf.IsAck(), tf.Data)
-	case http2.FrameRSTStream:
-		tf, ok := f.(*http2.RSTStreamFrame)
-		if !ok {
-			return ErrInvalidH2Frame
-		}
-		return fr.WriteRSTStream(tf.StreamID, tf.ErrCode)
-	case http2.FrameSettings:
-		tf, ok := f.(*http2.SettingsFrame)
-		if !ok {
-			return ErrInvalidH2Frame
-		}
-		if tf.IsAck() {
-			return fr.WriteSettingsAck()
-		}
-		var settings []http2.Setting
-		// NOTE: If we want to parse headers, need to handle
-		// settings where s.ID == http2.SettingHeaderTableSize and
-		// accordingly update the Framer options.
-		for i := 0; i < tf.NumSettings(); i++ {
-			settings = append(settings, tf.Setting(i))
-		}
-		return fr.WriteSettings(settings...)
-	case http2.FrameWindowUpdate:
-		tf, ok := f.(*http2.WindowUpdateFrame)
-		if !ok {
-			return ErrInvalidH2Frame
-		}
-		return fr.WriteWindowUpdate(tf.StreamID, tf.Increment)
-	case http2.FramePriority:
-		tf, ok := f.(*http2.PriorityFrame)
-		if !ok {
-			return ErrInvalidH2Frame
-		}
-		return fr.WritePriority(tf.StreamID, tf.PriorityParam)
-	case http2.FramePushPromise:
-		tf, ok := f.(*http2.PushPromiseFrame)
-		if !ok {
-			return ErrInvalidH2Frame
-		}
-		return fr.WritePushPromise(http2.PushPromiseParam{
-			StreamID:      tf.StreamID,
-			PromiseID:     tf.PromiseID,
-			BlockFragment: tf.HeaderBlockFragment(),
-			EndHeaders:    tf.HeadersEnded(),
-			PadLength:     0,
-		})
-	default:
-		return errors.New("Unsupported frame: " + string(f.Header().Type))
-	}
+	h2s := &http2.Server{}
+	h2s.ServeConn(conn, &http2.ServeConnOpts{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			// Build an absolute URL so handleHttp treats it as a proxy request.
+			if req.URL.Host == "" {
+				req.URL.Host = host
+			}
+			if req.URL.Scheme == "" {
+				req.URL.Scheme = "https"
+			}
+			req.RequestURI = ""
+			if remoteAddr != "" {
+				req.RemoteAddr = remoteAddr
+			}
+
+			proxy.handleHttpWithParent(w, req, parentCtx)
+		}),
+	})
 }

--- a/h2.go
+++ b/h2.go
@@ -62,6 +62,16 @@ func (proxy *ProxyHttpServer) serveH2(
 			if req.URL.Scheme == "" {
 				req.URL.Scheme = "https"
 			}
+			// Drop the default port for the scheme so the URL serialization
+			// matches the HTTP/1.1 MITM path (which uses the CONNECT
+			// request's Host header, typically without :443/:80). This
+			// keeps URL-based logging and routing consistent across h1/h2.
+			if h, p, ok := strings.Cut(req.URL.Host, ":"); ok {
+				if (req.URL.Scheme == "https" && p == "443") ||
+					(req.URL.Scheme == "http" && p == "80") {
+					req.URL.Host = h
+				}
+			}
 			req.RequestURI = ""
 			if remoteAddr != "" {
 				req.RemoteAddr = remoteAddr

--- a/h2.go
+++ b/h2.go
@@ -42,7 +42,12 @@ func (c *h2Conn) SetWriteDeadline(t time.Time) error {
 // parentCtx, if non-nil, supplies UserData and RoundTripper that should
 // be inherited by every per-stream ProxyCtx — matching the behaviour of
 // the HTTP/1.1 path in handleHttps.
-func (proxy *ProxyHttpServer) serveH2(clientReader io.Reader, clientConn net.Conn, host, remoteAddr string, parentCtx *ProxyCtx) {
+func (proxy *ProxyHttpServer) serveH2(
+	clientReader io.Reader,
+	clientConn net.Conn,
+	host, remoteAddr string,
+	parentCtx *ProxyCtx,
+) {
 	// Prepend the client preface so http2.Server.ServeConn can read it.
 	preface := io.MultiReader(strings.NewReader(http2.ClientPreface), clientReader)
 	conn := &h2Conn{r: preface, w: clientConn, conn: clientConn}

--- a/http.go
+++ b/http.go
@@ -8,7 +8,19 @@ import (
 )
 
 func (proxy *ProxyHttpServer) handleHttp(w http.ResponseWriter, r *http.Request) {
+	proxy.handleHttpWithParent(w, r, nil)
+}
+
+// handleHttpWithParent is the internal entry point that allows a parent
+// ProxyCtx (e.g. the outer CONNECT context for HTTP/2 streams) to seed
+// UserData and RoundTripper for each per-request context. When parent is
+// nil it behaves identically to handleHttp.
+func (proxy *ProxyHttpServer) handleHttpWithParent(w http.ResponseWriter, r *http.Request, parent *ProxyCtx) {
 	ctx := &ProxyCtx{Req: r, Session: atomic.AddInt64(&proxy.sess, 1), Proxy: proxy}
+	if parent != nil {
+		ctx.UserData = parent.UserData
+		ctx.RoundTripper = parent.RoundTripper
+	}
 
 	ctx.Logf("Got request %v %v %v %v", r.URL.Path, r.Host, r.Method, r.URL.String())
 	if !r.URL.IsAbs() {

--- a/https.go
+++ b/https.go
@@ -239,6 +239,13 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 				}
 
 				// Create a TLS connection over the TCP connection
+				// When AllowHTTP2 is set and the TLS config doesn't already
+				// specify protocols, advertise h2 so HTTP/2 clients can
+				// negotiate it and be handled by serveH2.
+				if proxy.AllowHTTP2 && len(tlsConfig.NextProtos) == 0 {
+					tlsConfig = tlsConfig.Clone()
+					tlsConfig.NextProtos = []string{"h2", "http/1.1"}
+				}
 				rawClientTls := tls.Server(client, tlsConfig)
 				client = rawClientTls
 				if err := rawClientTls.HandshakeContext(context.Background()); err != nil {
@@ -289,33 +296,31 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 					// information URL in the context when does HTTPS MITM
 					ctx.Req = req
 
-					req, resp := proxy.filterRequest(req, ctx)
-					if resp == nil {
-						if req.Method == "PRI" {
-							// Handle HTTP/2 connections.
-
-							// NOTE: As of 1.22, golang's http module will not recognize or
-							// parse the HTTP Body for PRI requests. This leaves the body of
-							// the http2.ClientPreface ("SM\r\n\r\n") on the wire which we need
-							// to clear before setting up the connection.
-							reader := clientReader.Reader()
-							_, err := reader.Discard(6)
-							if err != nil {
-								ctx.Warnf("Failed to process HTTP2 client preface: %v", err)
-								return false
-							}
-							if !proxy.AllowHTTP2 {
-								ctx.Warnf("HTTP2 connection failed: disallowed")
-								return false
-							}
-							tr := H2Transport{reader, client, tlsConfig, host}
-							if _, err := tr.RoundTrip(req); err != nil {
-								ctx.Warnf("HTTP2 connection failed: %v", err)
-							} else {
-								ctx.Logf("Exiting on EOF")
-							}
+					// Handle HTTP/2 PRI method before the filter chain.
+					// The PRI request itself (with URL path "*") is the HTTP/2
+					// connection preface — not a real request. Per-stream
+					// filtering happens inside serveH2, where http2.Server
+					// decodes each stream and dispatches it through
+					// proxy.handleHttp (and thus filterRequest) with the
+					// real method, path, and headers.
+					if req.Method == "PRI" {
+						reader := clientReader.Reader()
+						_, err := reader.Discard(6)
+						if err != nil {
+							ctx.Warnf("Failed to process HTTP2 client preface: %v", err)
 							return false
 						}
+						if !proxy.AllowHTTP2 {
+							ctx.Warnf("HTTP2 connection failed: disallowed")
+							return false
+						}
+						proxy.serveH2(reader, client, host, r.RemoteAddr, ctx)
+						ctx.Logf("Exiting on EOF")
+						return false
+					}
+
+					req, resp := proxy.filterRequest(req, ctx)
+					if resp == nil {
 						if err != nil {
 							if req.URL != nil {
 								ctx.Warnf("Illegal URL %s", scheme+"://"+r.Host+req.URL.Path)

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/elazarl/goproxy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"golang.org/x/net/http2"
 )
 
 var (
@@ -69,6 +71,16 @@ func init() {
 }
 
 type ConstantHanlder string
+
+// readBufferedConn wraps a net.Conn with a bufio.Reader so that bytes already
+// buffered (e.g. after reading an HTTP CONNECT response) are not lost when
+// handing the connection to a TLS client.
+type readBufferedConn struct {
+	net.Conn
+	r *bufio.Reader
+}
+
+func (c *readBufferedConn) Read(p []byte) (int, error) { return c.r.Read(p) }
 
 func (h ConstantHanlder) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, _ = io.WriteString(w, string(h))
@@ -1427,4 +1439,206 @@ func TestMITMResponseHTTP2ProtoVersion(t *testing.T) {
 	assert.Equal(t, "hello", string(body))
 	assert.Equal(t, 1, resp.ProtoMajor,
 		"MITM'd client should receive HTTP/1.x response, got %s", resp.Proto)
+}
+
+func TestH2MitmPassthrough(t *testing.T) {
+	env := newH2TestEnv(t, h2EchoPath)
+
+	resp, body := env.get(t, "/test-path")
+	assert.Equal(t, "/test-path", body)
+	assert.Equal(t, "HTTP/2.0", resp.Proto)
+}
+
+func TestH2MitmRequestFilter(t *testing.T) {
+	env := newH2TestEnv(t, h2EchoPath)
+
+	// Block /blocked, allow everything else.
+	env.proxy.OnRequest(goproxy.ReqConditionFunc(func(req *http.Request, _ *goproxy.ProxyCtx) bool {
+		return strings.Contains(req.URL.Path, "/blocked")
+	})).DoFunc(func(req *http.Request, _ *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+		return req, goproxy.NewResponse(req, goproxy.ContentTypeText, http.StatusForbidden, "blocked")
+	})
+
+	resp, body := env.get(t, "/allowed")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "/allowed", body)
+
+	resp, body = env.get(t, "/blocked")
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	assert.Equal(t, "blocked", body)
+}
+
+func TestH2MitmResponseFilter(t *testing.T) {
+	// X-Original is set by the upstream; X-Proxy is added by the proxy's
+	// OnResponse hook. Asserting both arrive at the client proves the
+	// response filter augments headers rather than replacing them.
+	env := newH2TestEnv(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Original", "yes")
+		_, _ = io.WriteString(w, "original")
+	})
+
+	env.proxy.OnResponse().DoFunc(func(resp *http.Response, _ *goproxy.ProxyCtx) *http.Response {
+		resp.Header.Set("X-Proxy", "injected")
+		return resp
+	})
+
+	resp, body := env.get(t, "/test")
+	assert.Equal(t, "original", body)
+	assert.Equal(t, "yes", resp.Header.Get("X-Original"))
+	assert.Equal(t, "injected", resp.Header.Get("X-Proxy"))
+}
+
+func TestH2MitmRewriteRequestHeaders(t *testing.T) {
+	env := newH2TestEnv(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, r.Header.Get("X-Custom"))
+	})
+
+	env.proxy.OnRequest().DoFunc(func(req *http.Request, _ *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+		req.Header.Set("X-Custom", "from-proxy")
+		return req, nil
+	})
+
+	_, body := env.get(t, "/echo")
+	assert.Equal(t, "from-proxy", body)
+}
+
+func TestH2MitmRewriteURL(t *testing.T) {
+	env := newH2TestEnv(t, h2EchoPath)
+
+	env.proxy.OnRequest().DoFunc(func(req *http.Request, _ *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+		req.URL.Path = "/rewritten"
+		return req, nil
+	})
+
+	_, body := env.get(t, "/original")
+	assert.Equal(t, "/rewritten", body)
+}
+
+func TestH2MitmRewriteResponseBody(t *testing.T) {
+	env := newH2TestEnv(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "original-body")
+	})
+
+	env.proxy.OnResponse().DoFunc(func(resp *http.Response, _ *goproxy.ProxyCtx) *http.Response {
+		resp.Body = io.NopCloser(strings.NewReader("replaced-body"))
+		return resp
+	})
+
+	_, body := env.get(t, "/test")
+	assert.Equal(t, "replaced-body", body)
+}
+
+func TestH2MitmMultipleStreams(t *testing.T) {
+	env := newH2TestEnv(t, h2EchoPath)
+
+	for i := 0; i < 5; i++ {
+		path := fmt.Sprintf("/stream-%d", i)
+		resp, body := env.get(t, path)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, path, body)
+	}
+}
+
+// --- H2 test helpers ---
+
+// h2EchoPath is a minimal upstream handler that echoes the request path.
+func h2EchoPath(w http.ResponseWriter, r *http.Request) {
+	_, _ = io.WriteString(w, r.URL.Path)
+}
+
+// h2TestEnv bundles a goproxy MITM proxy, an HTTP/2 upstream server, and a
+// lazy HTTP/2 client that tunnels through the proxy via CONNECT. All
+// resources are cleaned up via t.Cleanup.
+type h2TestEnv struct {
+	proxy       *goproxy.ProxyHttpServer
+	proxyURL    *url.URL
+	upstream    *httptest.Server
+	upstreamURL *url.URL
+
+	t      *testing.T
+	client *http.Client // lazily created so handler-registration tests can run before any request
+}
+
+func newH2TestEnv(t *testing.T, handler http.HandlerFunc) *h2TestEnv {
+	t.Helper()
+
+	upstream := httptest.NewUnstartedServer(handler)
+	upstream.EnableHTTP2 = true
+	upstream.StartTLS()
+	t.Cleanup(upstream.Close)
+
+	proxy := goproxy.NewProxyHttpServer()
+	proxy.AllowHTTP2 = true
+	proxy.OnRequest().HandleConnect(goproxy.AlwaysMitm)
+	proxySrv := httptest.NewServer(proxy)
+	t.Cleanup(proxySrv.Close)
+
+	return &h2TestEnv{
+		proxy:       proxy,
+		proxyURL:    mustParseURL(t, proxySrv.URL),
+		upstream:    upstream,
+		upstreamURL: mustParseURL(t, upstream.URL),
+		t:           t,
+	}
+}
+
+// get issues an HTTP/2 GET to the upstream at the given path and returns
+// the response and the full body. The response body is registered for
+// automatic cleanup.
+func (env *h2TestEnv) get(t *testing.T, path string) (*http.Response, string) {
+	t.Helper()
+
+	resp, err := env.h2Client().Get("https://" + env.upstreamURL.Host + path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp, string(body)
+}
+
+// h2Client opens (once per env) a CONNECT tunnel through the proxy to the
+// upstream, performs the inner TLS handshake with h2 ALPN, and returns an
+// http.Client whose http2.Transport is pinned to that single TLS connection.
+func (env *h2TestEnv) h2Client() *http.Client {
+	if env.client != nil {
+		return env.client
+	}
+	t := env.t
+	t.Helper()
+
+	conn, err := net.Dial("tcp", env.proxyURL.Host)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	connectReq, err := http.NewRequest(http.MethodConnect, "https://"+env.upstreamURL.Host, nil)
+	require.NoError(t, err)
+	require.NoError(t, connectReq.Write(conn))
+
+	br := bufio.NewReader(conn)
+	connectResp, err := http.ReadResponse(br, connectReq)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, connectResp.StatusCode)
+
+	tlsConn := tls.Client(&readBufferedConn{Conn: conn, r: br}, &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{"h2"},
+	})
+	require.NoError(t, tlsConn.HandshakeContext(context.Background()))
+
+	env.client = &http.Client{
+		Transport: &http2.Transport{
+			DialTLSContext: func(context.Context, string, string, *tls.Config) (net.Conn, error) {
+				return tlsConn, nil
+			},
+		},
+	}
+	return env.client
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	return u
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/elazarl/goproxy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"golang.org/x/net/http2"
 )
 
@@ -1694,7 +1693,9 @@ func newH2TestEnv(t *testing.T, handler http.HandlerFunc) *h2TestEnv {
 func (env *h2TestEnv) get(t *testing.T, path string) (*http.Response, string) {
 	t.Helper()
 
-	resp, err := env.h2Client().Get("https://" + env.upstreamURL.Host + path)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://"+env.upstreamURL.Host+path, nil)
+	require.NoError(t, err)
+	resp, err := env.h2Client().Do(req)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = resp.Body.Close() })
 
@@ -1713,11 +1714,14 @@ func (env *h2TestEnv) h2Client() *http.Client {
 	t := env.t
 	t.Helper()
 
-	conn, err := net.Dial("tcp", env.proxyURL.Host)
+	conn, err := (&net.Dialer{}).DialContext(context.Background(), "tcp", env.proxyURL.Host)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = conn.Close() })
 
-	connectReq, err := http.NewRequest(http.MethodConnect, "https://"+env.upstreamURL.Host, nil)
+	connectReq, err := http.NewRequestWithContext(
+		context.Background(), http.MethodConnect,
+		"https://"+env.upstreamURL.Host, nil,
+	)
 	require.NoError(t, err)
 	require.NoError(t, connectReq.Write(conn))
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1595,7 +1595,7 @@ func TestH2MitmResponseFilter(t *testing.T) {
 
 func TestH2MitmRewriteRequestHeaders(t *testing.T) {
 	env := newH2TestEnv(t, func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.WriteString(w, r.Header.Get("X-Custom"))
+		_, _ = io.WriteString(w, html.EscapeString(r.Header.Get("X-Custom")))
 	})
 
 	env.proxy.OnRequest().DoFunc(func(req *http.Request, _ *goproxy.ProxyCtx) (*http.Request, *http.Response) {
@@ -1648,7 +1648,7 @@ func TestH2MitmMultipleStreams(t *testing.T) {
 
 // h2EchoPath is a minimal upstream handler that echoes the request path.
 func h2EchoPath(w http.ResponseWriter, r *http.Request) {
-	_, _ = io.WriteString(w, r.URL.Path)
+	_, _ = io.WriteString(w, html.EscapeString(r.URL.Path))
 }
 
 // h2TestEnv bundles a goproxy MITM proxy, an HTTP/2 upstream server, and a


### PR DESCRIPTION
## Summary

This PR replaces the frame-level HTTP/2 forwarder (`H2Transport`) with a
proper HTTP/2 termination layer. Each HTTP/2 stream is decoded into a
standard `*http.Request` and dispatched through the existing
`filterRequest` → `RoundTrip` → `filterResponse` pipeline, exactly like
HTTP/1.1.

## Why

The previous `H2Transport` copied frames between the client's and
upstream's `http2.Framer`. While this worked for blind passthrough, it
was structurally incompatible with goproxy's value proposition:

- Handlers registered via `OnRequest` / `OnResponse` never ran for H2
  traffic — the proxy never had decoded `*http.Request` objects.
- `:path`, `:method`, headers, and bodies were invisible to user code,
  so URL/header/body inspection or rewriting was impossible.
- gRPC traffic (HTTP/2 with paths like `/pkg.Service/Method`) was
  particularly affected: the only thing observable was the destination
  host, which is far too coarse for any kind of per-RPC policy.

After this change H2 traffic is a first-class citizen of the filter
chain.

## What changed

### Core
- **`h2.go`**: `H2Transport` and the per-frame forwarding code are
  removed. New `serveH2` adapts the decrypted client conn into a
  `net.Conn` and drives it with `http2.Server.ServeConn`. The handler
  rewrites each request to look like an absolute-URL proxy request and
  hands it to the standard `handleHttp` path.
- **`https.go`**: The `PRI` method is now handled *before* the filter
  chain (it is the H2 connection preface, not a real request). When
  `AllowHTTP2` is true and the user's TLS config does not pin
  `NextProtos`, `h2`/`http/1.1` are advertised automatically so that
  H2 clients can negotiate without requiring callers to update their
  `TLSConfig` callback.
- **`http.go`**: New internal `handleHttpWithParent` accepts an outer
  `*ProxyCtx` and seeds `UserData` and `RoundTripper` for each
  per-stream context. This matches the semantics already used by the
  HTTP/1.1 path and prevents H2 streams from silently losing context
  set by an `OnConnect` handler.

### Lifecycle / correctness
- `h2Conn` now delegates `Close`, `SetDeadline`, `SetReadDeadline`,
  and `SetWriteDeadline` to the underlying connection. The previous
  no-op implementations meant `http2.Server` could neither enforce
  idle/read/write timeouts nor cleanly tear the connection down on
  GOAWAY or error.
- The original client `RemoteAddr` from the outer CONNECT is now
  propagated to each decoded H2 `*http.Request`.

### Tests
New `TestH2Mitm*` cases cover:

- Passthrough (`/test-path` echoed end-to-end, `Proto == HTTP/2.0`)
- Per-stream request filtering (`/blocked` returns 403, `/allowed`
  reaches upstream)
- Per-stream response filtering (proxy adds a header, upstream's
  header is preserved)
- Request header rewriting
- URL rewriting
- Response body replacement
- Multiple streams sharing one HTTP/2 connection through the proxy

A small `h2TestEnv` helper bundles the proxy, an in-process H2
upstream, a CONNECT-tunneled TLS conn, and a pinned
`http2.Transport`-based client to keep each test ~5 lines.

## Backwards compatibility

- `AllowHTTP2 = false` (the default) is unchanged: H2 connections are
  rejected exactly as before.
- Existing HTTP/1.1 behavior is unchanged.
- Callers that already set `tls.Config.NextProtos` keep full control —
  the auto-injection only kicks in when they leave it empty.
- The exported `H2Transport` type and `ErrInvalidH2Frame` are removed.
  These were only useful in conjunction with the previous forwarder
  and have no migration path because the new design does not expose
  raw frames; if anyone depends on them, they should not enable
  `AllowHTTP2` and should keep H2 as an opaque CONNECT tunnel.

## How tested

```
go test ./...
```