### PR TITLE
http: forward upstream response trailers

### DIFF
--- a/http.go
+++ b/http.go
@@ -62,6 +62,20 @@ func (proxy *ProxyHttpServer) handleHttp(w http.ResponseWriter, r *http.Request)
 		resp.Header.Del("Content-Length")
 	}
 	copyHeaders(w.Header(), resp.Header, proxy.KeepDestinationHeaders)
+
+	// Announce trailers known at this point (HTTP/1.1 with pre-announced
+	// Trailer header). Setting "Trailer" before WriteHeader makes
+	// http.Server commit to chunked encoding (h1) or a trailing HEADERS
+	// frame (h2), which is required for any trailers to be forwarded.
+	// Mirrors net/http/httputil.ReverseProxy.
+	announcedTrailers := len(resp.Trailer)
+	if announcedTrailers > 0 {
+		trailerKeys := make([]string, 0, announcedTrailers)
+		for k := range resp.Trailer {
+			trailerKeys = append(trailerKeys, k)
+		}
+		w.Header().Add("Trailer", strings.Join(trailerKeys, ", "))
+	}
 	w.WriteHeader(resp.StatusCode)
 
 	if isWebSocketHandshake(resp.Header) {
@@ -92,6 +106,33 @@ func (proxy *ProxyHttpServer) handleHttp(w http.ResponseWriter, r *http.Request)
 	nr, err := io.Copy(copyWriter, resp.Body)
 	if err := resp.Body.Close(); err != nil {
 		ctx.Warnf("Can't close response body %v", err)
+	}
+
+	// Forward upstream response trailers. Two cases:
+	//   1. resp.Trailer count == announcedTrailers: every trailer was
+	//      pre-announced, so http.Server is already looking for them
+	//      under the unprefixed names — write values there.
+	//   2. resp.Trailer count > announcedTrailers (HTTP/2 servers, or
+	//      late additions): use http.TrailerPrefix so http.Server emits
+	//      them as trailers without needing the leading announcement.
+	//      We still need a Flush below to force chunked encoding for
+	//      bodies short enough that http.Server would otherwise inline
+	//      them with Content-Length and silently drop trailers.
+	if len(resp.Trailer) > 0 {
+		// Force chunking even when the body is small / fully buffered.
+		if rc := http.NewResponseController(w); rc != nil {
+			_ = rc.Flush()
+		}
+	}
+	if len(resp.Trailer) == announcedTrailers {
+		copyHeaders(w.Header(), resp.Trailer, proxy.KeepDestinationHeaders)
+	} else {
+		for k, vs := range resp.Trailer {
+			k = http.TrailerPrefix + k
+			for _, v := range vs {
+				w.Header().Add(k, v)
+			}
+		}
 	}
 	ctx.Logf("Copied %v bytes to client error=%v", nr, err)
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1428,3 +1428,72 @@ func TestMITMResponseHTTP2ProtoVersion(t *testing.T) {
 	assert.Equal(t, 1, resp.ProtoMajor,
 		"MITM'd client should receive HTTP/1.x response, got %s", resp.Proto)
 }
+
+// TestTrailersForwarded verifies that response trailers (e.g. gRPC's
+// grpc-status, grpc-message) emitted by the upstream server are forwarded
+// through the proxy to the client.
+//
+// Regression test for https://github.com/elazarl/goproxy/issues/408
+// ("Proxying grpc/h2c requests fail with 'server closed the stream
+// without sending trailers'").
+func TestTrailersForwarded(t *testing.T) {
+	const (
+		bodyText     = "hello world"
+		announcedKey = "Grpc-Status"
+		announcedVal = "0"
+		unannouncedK = "X-Late-Trailer"
+		unannouncedV = "abc"
+	)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Pre-announce one trailer (h1 chunked path).
+		w.Header().Set("Trailer", announcedKey)
+		w.Header().Set("Content-Type", "application/grpc")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, bodyText)
+		// Pre-announced: value goes under the unprefixed key.
+		w.Header().Set(announcedKey, announcedVal)
+		// Late / unannounced: must use TrailerPrefix on the upstream,
+		// which httputil-style proxy code paths must forward via
+		// TrailerPrefix on the client side too.
+		w.Header().Set(http.TrailerPrefix+unannouncedK, unannouncedV)
+	}))
+	defer upstream.Close()
+
+	client, proxySrv := oneShotProxy(goproxy.NewProxyHttpServer())
+	defer proxySrv.Close()
+
+	resp, err := client.Get(upstream.URL + "/anything")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, bodyText, string(body))
+
+	// resp.Trailer is only populated after the body is fully consumed.
+	require.Equal(t, announcedVal, resp.Trailer.Get(announcedKey),
+		"upstream pre-announced trailer should be forwarded by the proxy")
+	require.Equal(t, unannouncedV, resp.Trailer.Get(unannouncedK),
+		"upstream late/unannounced trailer should be forwarded by the proxy")
+}
+
+// TestNoTrailersUnchanged is a sanity check that responses without trailers
+// are unaffected by the trailer-forwarding code.
+func TestNoTrailersUnchanged(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer upstream.Close()
+
+	client, proxySrv := oneShotProxy(goproxy.NewProxyHttpServer())
+	defer proxySrv.Close()
+
+	resp, err := client.Get(upstream.URL + "/")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "ok", strings.TrimSpace(string(body)))
+	require.Empty(t, resp.Trailer)
+}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1463,7 +1463,7 @@ func TestTrailersForwarded(t *testing.T) {
 	client, proxySrv := oneShotProxy(goproxy.NewProxyHttpServer())
 	defer proxySrv.Close()
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, upstream.URL + "/anything", nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, upstream.URL+"/anything", nil)
 	require.NoError(t, err)
 
 	resp, err := client.Do(req)
@@ -1492,7 +1492,7 @@ func TestNoTrailersUnchanged(t *testing.T) {
 	client, proxySrv := oneShotProxy(goproxy.NewProxyHttpServer())
 	defer proxySrv.Close()
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, upstream.URL + "/", nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, upstream.URL+"/", nil)
 	require.NoError(t, err)
 
 	resp, err := client.Do(req)

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1463,7 +1463,10 @@ func TestTrailersForwarded(t *testing.T) {
 	client, proxySrv := oneShotProxy(goproxy.NewProxyHttpServer())
 	defer proxySrv.Close()
 
-	resp, err := client.Get(upstream.URL + "/anything")
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, upstream.URL + "/anything", nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
@@ -1489,7 +1492,10 @@ func TestNoTrailersUnchanged(t *testing.T) {
 	client, proxySrv := oneShotProxy(goproxy.NewProxyHttpServer())
 	defer proxySrv.Close()
 
-	resp, err := client.Get(upstream.URL + "/")
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, upstream.URL + "/", nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(upstream.URL + "/")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1495,7 +1495,7 @@ func TestNoTrailersUnchanged(t *testing.T) {
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, upstream.URL + "/", nil)
 	require.NoError(t, err)
 
-	resp, err := client.Do(upstream.URL + "/")
+	resp, err := client.Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
When the upstream responds with trailers (HTTP/1.1 chunked Trailer block or HTTP/2 trailing HEADERS frame, as gRPC requires), goproxy was silently discarding them. The grpc-go client then surfaced the missing grpc-status as:

    rpc error: code = Internal desc = server closed the stream without sending trailers

`handleHttp` now mirrors net/http/httputil.ReverseProxy's trailer logic:

  1. Pre-announce upstream trailer keys via the "Trailer" header before WriteHeader. This is what makes net/http commit to chunked encoding (h1) or a trailing HEADERS frame (h2); without it, short bodies get a Content-Length and trailers are dropped on the floor.
  2. After body copy + Body.Close (which is what populates resp.Trailer for h2 trailing-HEADERS), force a Flush so the server can no longer buffer to a fixed-length response.
  3. Forward values: under unprefixed keys when every trailer was pre-announced (the gRPC-over-h1-upstream case), otherwise via http.TrailerPrefix so dynamically-added trailers also get through.