### PR TITLE
fix: do not send Transfer-Encoding for 204 and 1xx status codes

### DIFF
--- a/https.go
+++ b/https.go
@@ -379,9 +379,12 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 						// might incorrectly leave it instead of setting it to -1 when the length is unknown (but we
 						// also check that the Content-Length header is empty, so there is no issue with empty bodies).
 						//
-						// 304 Not Modified responses MUST NOT have a body (RFC 7232),
-						// so don't set Transfer-Encoding for them.
-						if resp.StatusCode != http.StatusNotModified {
+						// 1xx, 204 No Content and 304 Not Modified responses MUST NOT
+						// have a body (RFC 7230 §3.3.2, RFC 7232 §4.1), so don't set
+						// Transfer-Encoding for them.
+						if resp.StatusCode != http.StatusNotModified &&
+							resp.StatusCode != http.StatusNoContent &&
+							resp.StatusCode >= 200 {
 							resp.ContentLength = -1
 							resp.Header.Del("Content-Length")
 							resp.TransferEncoding = []string{"chunked"}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1200,6 +1200,28 @@ func TestMITMEmptyBody(t *testing.T) {
 	assert.EqualValues(t, 0, resp.ContentLength)
 }
 
+func TestMITMNoContentResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	proxy := goproxy.NewProxyHttpServer()
+	proxy.OnRequest().HandleConnect(goproxy.AlwaysMitm)
+
+	client, l := oneShotProxy(proxy)
+	defer l.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.NotContains(t, resp.TransferEncoding, "chunked")
+}
+
 func TestMITMOverwriteAlreadyEmptyBody(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(nil)


### PR DESCRIPTION
Since 204 and 1xx responses must not have a body per their RFC, we should not set the `Transfer-Encoding: chunked` header to avoid errors from browsers / http clients.

Related to elazarl/goproxy#732