### PR TITLE
 Avoid chunked response when there is http.NoBody 

### DIFF
--- a/https.go
+++ b/https.go
@@ -378,14 +378,9 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 						// We include 0 in resp.ContentLength <= 0 because 0 is the field zero value and some user
 						// might incorrectly leave it instead of setting it to -1 when the length is unknown (but we
 						// also check that the Content-Length header is empty, so there is no issue with empty bodies).
-						//
-						// 304 Not Modified responses MUST NOT have a body (RFC 7232),
-						// so don't set Transfer-Encoding for them.
-						if resp.StatusCode != http.StatusNotModified {
-							resp.ContentLength = -1
-							resp.Header.Del("Content-Length")
-							resp.TransferEncoding = []string{"chunked"}
-						}
+						resp.ContentLength = -1
+						resp.Header.Del("Content-Length")
+						resp.TransferEncoding = []string{"chunked"}
 					}
 
 					// The MITM'd client speaks HTTP/1.1, but the upstream

--- a/https.go
+++ b/https.go
@@ -372,7 +372,8 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 					resp = proxy.filterResponse(resp, ctx)
 					bodyModified := resp.Body != origBody
 					defer resp.Body.Close()
-					if bodyModified || (resp.ContentLength <= 0 && resp.Header.Get("Content-Length") == "") {
+					if resp.Body != http.NoBody && (bodyModified ||
+						(resp.ContentLength <= 0 && resp.Header.Get("Content-Length") == "")) {
 						// Return chunked encoded response when we don't know the length of the resp, if the body
 						// has been modified by the response handler or if there is no content length in the response.
 						// We include 0 in resp.ContentLength <= 0 because 0 is the field zero value and some user

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1208,6 +1208,29 @@ func TestMITMEmptyBody(t *testing.T) {
 	assert.EqualValues(t, 0, resp.ContentLength)
 }
 
+func TestMITMNoContentResponse(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "0")
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer srv.Close()
+
+	proxy := goproxy.NewProxyHttpServer()
+	proxy.Tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	proxy.OnRequest().HandleConnect(goproxy.AlwaysMitm)
+	client, l := oneShotProxy(proxy)
+	defer l.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	assert.Equal(t, http.StatusNotModified, resp.StatusCode)
+	assert.NotContains(t, resp.TransferEncoding, "chunked")
+}
+
 func TestMITMOverwriteAlreadyEmptyBody(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(nil)

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1210,7 +1210,6 @@ func TestMITMEmptyBody(t *testing.T) {
 
 func TestMITMNoContentResponse(t *testing.T) {
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Length", "0")
 		w.WriteHeader(http.StatusNotModified)
 	}))
 	defer srv.Close()


### PR DESCRIPTION
Related to https://github.com/elazarl/goproxy/issues/732