### PR TITLE
fix: use client TLS config for HTTP/2 MITM connections

### DIFF
--- a/https.go
+++ b/https.go
@@ -342,7 +342,13 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 								ctx.Warnf("HTTP2 connection failed: disallowed")
 								return false
 							}
-							tr := H2Transport{reader, client, tlsConfig, host}
+							tlsCfg := proxy.Tr.TLSClientConfig
+							if tlsCfg == nil {
+								tlsCfg = &tls.Config{}
+							} else {
+								tlsCfg = tlsCfg.Clone()
+							}
+							tr := H2Transport{reader, client, tlsCfg, host}
 							if _, err := tr.RoundTrip(req); err != nil {
 								ctx.Warnf("HTTP2 connection failed: %v", err)
 							} else {


### PR DESCRIPTION
Fixes #727

## Summary

The `H2Transport` in HTTP/2 MITM mode was incorrectly receiving the server-side MITM TLS config (`tlsConfig`) instead of the proxy's outbound client TLS config (`proxy.Tr.TLSClientConfig`). This caused HTTP/2 connections to the upstream server to ignore proxy TLS settings, particularly affecting mTLS scenarios.

## Root Cause

In `https.go` line 345, `tlsConfig` (set at line 261-273) is the **server-side** TLS configuration used for the MITM handshake with the client (`tls.Server(client, tlsConfig)`). However, `H2Transport` needs a **client-side** TLS configuration to establish the outbound connection to the upstream server (`tls.Client(rawServerTLS, r.TLSConfig)` in `h2.go:44`).

## Fix

Replace `tlsConfig` with `proxy.Tr.TLSClientConfig` (the proxy's outbound client TLS config). Handle the nil case by creating a default `&tls.Config{}` when `TLSClientConfig` is not set. Clone the config before passing to avoid mutation side effects (the `H2Transport` sets `NextProtos` on the config).