### PR TITLE
fix(https): close client connection when target connection errors

### DIFF
--- a/https.go
+++ b/https.go
@@ -473,12 +473,20 @@ func copyOrWarn(ctx *ProxyCtx, dst io.Writer, src io.Reader) error {
 
 func copyAndClose(ctx *ProxyCtx, dst, src halfClosable, wg *sync.WaitGroup) {
 	_, err := io.Copy(dst, src)
-	if err != nil && !errors.Is(err, net.ErrClosed) {
-		ctx.Warnf("Error copying to client: %s", err.Error())
+	if err != nil {
+		if !errors.Is(err, net.ErrClosed) {
+			ctx.Warnf("Error copying to client: %s", err.Error())
+		}
+		// Fully close dst to unblock any goroutine blocked on
+		// io.Copy reading from it. Half-close (CloseWrite/CloseRead)
+		// would not interrupt a pending read, leaving the other
+		// goroutine stuck and the client connection never closed.
+		_ = dst.Close()
+		_ = src.Close()
+	} else {
+		_ = dst.CloseWrite()
+		_ = src.CloseRead()
 	}
-
-	_ = dst.CloseWrite()
-	_ = src.CloseRead()
 	wg.Done()
 }
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1576,7 +1576,7 @@ func TestNoTrailersUnchanged(t *testing.T) {
 func TestTransparentTunnelClosesClientConnOnTargetError(t *testing.T) {
 	// Target server: closes connection immediately after reading from client.
 	// This simulates a target IO error (timeout, connection reset).
-	targetListener, err := net.Listen("tcp", "127.0.0.1:0")
+	targetListener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	defer targetListener.Close()
 
@@ -1600,7 +1600,7 @@ func TestTransparentTunnelClosesClientConnOnTargetError(t *testing.T) {
 	require.NoError(t, err)
 
 	// Connect to proxy.
-	clientConn, err := net.Dial("tcp", proxyURL.Host)
+	clientConn, err := (&net.Dialer{}).DialContext(context.Background(), "tcp", proxyURL.Host)
 	require.NoError(t, err)
 	defer clientConn.Close()
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1566,3 +1566,86 @@ func TestNoTrailersUnchanged(t *testing.T) {
 	require.Equal(t, "ok", strings.TrimSpace(string(body)))
 	require.Empty(t, resp.Trailer)
 }
+
+// TestTransparentTunnelClosesClientConnOnTargetError verifies that when the
+// target connection closes unexpectedly during a transparent TCP tunnel
+// (ConnectAccept path), the client connection is also closed so the client
+// doesn't hang indefinitely.
+//
+// Regression test for https://github.com/elazarl/goproxy/issues/657
+func TestTransparentTunnelClosesClientConnOnTargetError(t *testing.T) {
+	// Target server: closes connection immediately after reading from client.
+	// This simulates a target IO error (timeout, connection reset).
+	targetListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer targetListener.Close()
+
+	targetConnCh := make(chan net.Conn, 1)
+	go func() {
+		conn, err := targetListener.Accept()
+		if err != nil {
+			return
+		}
+		targetConnCh <- conn
+	}()
+
+	// Proxy server: transparent tunnel (ConnectAccept, the default).
+	// No HandleConnect handler means OkConnect (transparent tunnel) is used.
+	proxy := goproxy.NewProxyHttpServer()
+
+	proxyServer := httptest.NewServer(proxy)
+	defer proxyServer.Close()
+
+	proxyURL, err := url.Parse(proxyServer.URL)
+	require.NoError(t, err)
+
+	// Connect to proxy.
+	clientConn, err := net.Dial("tcp", proxyURL.Host)
+	require.NoError(t, err)
+	defer clientConn.Close()
+
+	// Send CONNECT request.
+	connectReq := &http.Request{
+		Method: http.MethodConnect,
+		URL:    &url.URL{Opaque: targetListener.Addr().String()},
+		Host:   targetListener.Addr().String(),
+		Header: make(http.Header),
+	}
+	require.NoError(t, connectReq.Write(clientConn))
+
+	// Read CONNECT response.
+	br := bufio.NewReader(clientConn)
+	connectResp, err := http.ReadResponse(br, connectReq)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, connectResp.StatusCode)
+
+	// Wait for target to accept connection.
+	var targetConn net.Conn
+	select {
+	case targetConn = <-targetConnCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for target connection")
+	}
+
+	// Send data through the tunnel so the target starts reading.
+	_, err = clientConn.Write([]byte("hello"))
+	require.NoError(t, err)
+
+	// Target closes connection (simulates IO error).
+	require.NoError(t, targetConn.Close())
+
+	// Verify client connection is closed within timeout.
+	done := make(chan struct{})
+	go func() {
+		buf := make([]byte, 1024)
+		_, _ = clientConn.Read(buf)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Connection was closed — this is the expected behavior.
+	case <-time.After(3 * time.Second):
+		t.Fatal("client connection was not closed after target closed; client would hang indefinitely")
+	}
+}


### PR DESCRIPTION
Fixes #657

## Bug Description
When a target connection has an IO error (read timeout or connection reset)
during a transparent HTTPS tunnel (CONNECT Accept path), only the target-side
connection is closed. The client-side connection is left open, causing clients
to hang indefinitely waiting to write the POST body.

## Root Cause
The `copyAndClose` function in `https.go` only half-closed connections
(CloseWrite/CloseRead) on both success and error. A half-close does not
unblock a goroutine blocked on `io.Copy` reading from the same connection,
leaving `wg.Wait()` hanging and the client connection never closed.

## Fix
In `copyAndClose`, when `io.Copy` returns an error, fully `Close()` both
the destination and source connections. This unblocks any goroutine blocked
on `io.Copy` reading from those connections, allowing `wg.Wait()` to complete
and the cleanup code (proxyClientTCP.Close(), targetTCP.Close()) to run.

On success, the original graceful half-close behavior is preserved.

## Test
Added `TestTransparentTunnelClosesClientConnOnTargetError` regression test
that verifies the client connection is closed within a timeout when the target
connection is unexpectedly closed.
