### PR TITLE
Remove redundant certificate Leaf set starting from Go 1.23

### DIFF
--- a/certs.go
+++ b/certs.go
@@ -2,7 +2,6 @@ package goproxy
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 )
 
 // GoproxyCa is the built-in self-signed CA certificate used by default for MITM interception.
@@ -20,10 +19,6 @@ func init() {
 	GoproxyCa, err = tls.X509KeyPair(CA_CERT, CA_KEY)
 	if err != nil {
 		panic("Error parsing builtin CA: " + err.Error())
-	}
-
-	if GoproxyCa.Leaf, err = x509.ParseCertificate(GoproxyCa.Certificate[0]); err != nil {
-		panic("Error parsing builtin CA leaf: " + err.Error())
 	}
 }
 

--- a/examples/customca/main.go
+++ b/examples/customca/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 	"flag"
 	"log"
 	"net/http"
@@ -34,9 +33,6 @@ func main() {
 func parseCA(caCert, caKey []byte) (*tls.Certificate, error) {
 	parsedCert, err := tls.X509KeyPair(caCert, caKey)
 	if err != nil {
-		return nil, err
-	}
-	if parsedCert.Leaf, err = x509.ParseCertificate(parsedCert.Certificate[0]); err != nil {
 		return nil, err
 	}
 	return &parsedCert, nil


### PR DESCRIPTION
Starting from Go 1.23, `tls.X509KeyPair` also populates the Leaf field.

Documentation:
```
X509KeyPair parses a public/private key pair from a pair of PEM encoded data. On successful return, Certificate.Leaf will be populated.
Before Go 1.23 Certificate.Leaf was left nil, and the parsed certificate was discarded. This behavior can be re-enabled by setting "x509keypairleaf=0" in the GODEBUG environment variable.
```

Go.mod is currently 1.23 so we can apply this code easily