### PR TITLE
Stream MITM response bodies

### DIFF
--- a/https.go
+++ b/https.go
@@ -2,6 +2,7 @@ package goproxy
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -18,6 +19,48 @@ import (
 	"github.com/elazarl/goproxy/internal/http1parser"
 	"github.com/elazarl/goproxy/internal/signer"
 )
+
+var responseHeadTerminator = []byte("\r\n\r\n")
+
+type responseHeadWriter struct {
+	writer    io.Writer
+	head      bytes.Buffer
+	wroteHead bool
+}
+
+func (w *responseHeadWriter) Write(p []byte) (int, error) {
+	if w.wroteHead {
+		return w.writer.Write(p)
+	}
+
+	buffered := w.head.Len()
+	_, _ = w.head.Write(p)
+	headEnd := bytes.Index(w.head.Bytes(), responseHeadTerminator)
+	if headEnd < 0 {
+		return len(p), nil
+	}
+	headEnd += len(responseHeadTerminator)
+
+	data := w.head.Bytes()
+	n, err := w.writer.Write(data[:headEnd])
+	if err != nil || n != headEnd {
+		current := max(0, min(len(p), n-buffered))
+		if err == nil {
+			err = io.ErrShortWrite
+		}
+		return current, err
+	}
+
+	w.wroteHead = true
+	body := data[headEnd:]
+	w.head.Reset()
+	if len(body) == 0 {
+		return len(p), nil
+	}
+
+	n, err = w.writer.Write(body)
+	return headEnd - buffered + n, err
+}
 
 // ConnectActionLiteral defines the action the proxy should take
 // when it receives an HTTP CONNECT request from a client.
@@ -426,13 +469,9 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 						return false
 					}
 
-					bw := bufio.NewWriter(client)
-					if err := resp.Write(bw); err != nil {
+					writer := &responseHeadWriter{writer: client}
+					if err := resp.Write(writer); err != nil {
 						ctx.Warnf("Cannot write response from mitm'd client: %v", err)
-						return false
-					}
-					if err := bw.Flush(); err != nil {
-						ctx.Warnf("Cannot flush response from mitm'd client: %v", err)
 						return false
 					}
 

--- a/https_head_test.go
+++ b/https_head_test.go
@@ -3,6 +3,7 @@ package goproxy_test
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -38,6 +39,65 @@ func (l *countingListener) Accept() (net.Conn, error) {
 		return c, err
 	}
 	return &countingConn{Conn: c, writes: l.writes}, nil
+}
+
+func TestMitmResponseStreamsSSE(t *testing.T) {
+	const event = "data: ready\n\n"
+
+	release := make(chan struct{})
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, event)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-release
+	}))
+	defer upstream.Close()
+
+	proxy := goproxy.NewProxyHttpServer()
+	proxy.Tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	proxy.OnRequest().HandleConnect(goproxy.AlwaysMitm)
+
+	proxyServer := httptest.NewServer(proxy)
+	defer proxyServer.Close()
+	defer close(release)
+	proxyURL, err := url.Parse(proxyServer.URL)
+	require.NoError(t, err)
+
+	client := &http.Client{Transport: &http.Transport{
+		Proxy:           http.ProxyURL(proxyURL),
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+
+	result := make(chan error, 1)
+	go func() {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, upstream.URL, nil)
+		if err != nil {
+			result <- err
+			return
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			result <- err
+			return
+		}
+		defer resp.Body.Close()
+		body := make([]byte, len(event))
+		_, err = io.ReadFull(resp.Body, body)
+		if err == nil && string(body) != event {
+			err = fmt.Errorf("received event %q, want %q", body, event)
+		}
+		result <- err
+	}()
+
+	select {
+	case err := <-result:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("SSE event was buffered while the upstream response remained open")
+	}
 }
 
 // TestMitmResponseHeadIsNotFragmented ensures the MITM response head (status line


### PR DESCRIPTION
Fixes SSE streaming through HTTPS MITM.  

Since v1.8.5/#787, the existing flush runs only after `resp.Write` finishes, but `resp.Write` includes the long-lived response body and therefore never returns for SSE. Small events remain stuck in the 4 KiB buffer.  

This change buffers only the response headers, then streams the body writes directly, preserving header coalescing.  
Adds regression coverage.