### PR TITLE
Close response bodies exactly once; fix MITM origBody leak

### DIFF
--- a/body_close_test.go
+++ b/body_close_test.go
@@ -1,0 +1,126 @@
+package goproxy_test
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/elazarl/goproxy"
+)
+
+// strictBody errors (rather than tolerating) a second Close, like response
+// bodies from custom RoundTrippers that release resources exactly once.
+type strictBody struct {
+	io.Reader
+	closes atomic.Int32
+}
+
+func (b *strictBody) Close() error {
+	if b.closes.Add(1) > 1 {
+		return errors.New("double close")
+	}
+	return nil
+}
+
+// TestRoundTripperBodyClosedExactlyOnce guards the ctx.RoundTrip body
+// wrapping: handleHttp pairs a deferred Close with an explicit Close after
+// io.Copy, which double-closed bodies returned by custom RoundTrippers.
+func TestRoundTripperBodyClosedExactlyOnce(t *testing.T) {
+	body := &strictBody{Reader: strings.NewReader("hello")}
+
+	proxy := goproxy.NewProxyHttpServer()
+	proxy.OnRequest().DoFunc(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+		ctx.RoundTripper = goproxy.RoundTripperFunc(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Response, error) {
+			return &http.Response{
+				Request:       req,
+				StatusCode:    http.StatusOK,
+				Proto:         "HTTP/1.1",
+				ProtoMajor:    1,
+				ProtoMinor:    1,
+				Header:        http.Header{"Content-Length": []string{"5"}},
+				ContentLength: 5,
+				Body:          body,
+			}, nil
+		})
+		return req, nil
+	})
+	proxySrv := httptest.NewServer(proxy)
+	defer proxySrv.Close()
+
+	proxyURL, _ := url.Parse(proxySrv.URL)
+	client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
+	resp, err := client.Get("http://example.com/object")
+	if err != nil {
+		t.Fatalf("request through proxy failed: %v", err)
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading response: %v", err)
+	}
+	resp.Body.Close()
+	if string(got) != "hello" {
+		t.Fatalf("unexpected body: %q", got)
+	}
+	if n := body.closes.Load(); n != 1 {
+		t.Fatalf("round tripper body closed %d times, want exactly 1", n)
+	}
+}
+
+// TestFilterSwappedBodyBothClosed guards the origBody handling: when a
+// response filter replaces the body, both the replacement and the original
+// must be closed exactly once.
+func TestFilterSwappedBodyBothClosed(t *testing.T) {
+	original := &strictBody{Reader: strings.NewReader("original")}
+	replacement := &strictBody{Reader: strings.NewReader("replaced")}
+
+	proxy := goproxy.NewProxyHttpServer()
+	proxy.OnRequest().DoFunc(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+		ctx.RoundTripper = goproxy.RoundTripperFunc(func(req *http.Request, ctx *goproxy.ProxyCtx) (*http.Response, error) {
+			return &http.Response{
+				Request:       req,
+				StatusCode:    http.StatusOK,
+				Proto:         "HTTP/1.1",
+				ProtoMajor:    1,
+				ProtoMinor:    1,
+				Header:        http.Header{"Content-Length": []string{"8"}},
+				ContentLength: 8,
+				Body:          original,
+			}, nil
+		})
+		return req, nil
+	})
+	proxy.OnResponse().DoFunc(func(resp *http.Response, ctx *goproxy.ProxyCtx) *http.Response {
+		resp.Body.Close()
+		resp.Body = replacement
+		resp.ContentLength = 8
+		return resp
+	})
+	proxySrv := httptest.NewServer(proxy)
+	defer proxySrv.Close()
+
+	proxyURL, _ := url.Parse(proxySrv.URL)
+	client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)}}
+	resp, err := client.Get("http://example.com/object")
+	if err != nil {
+		t.Fatalf("request through proxy failed: %v", err)
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading response: %v", err)
+	}
+	resp.Body.Close()
+	if string(got) != "replaced" {
+		t.Fatalf("unexpected body: %q", got)
+	}
+	if n := original.closes.Load(); n != 1 {
+		t.Fatalf("original body closed %d times, want exactly 1", n)
+	}
+	if n := replacement.closes.Load(); n != 1 {
+		t.Fatalf("replacement body closed %d times, want exactly 1", n)
+	}
+}

--- a/ctx.go
+++ b/ctx.go
@@ -3,9 +3,11 @@ package goproxy
 import (
 	"context"
 	"crypto/tls"
+	"io"
 	"mime"
 	"net"
 	"net/http"
+	"sync"
 )
 
 // ProxyCtx is the Proxy context, contains useful information about every request. It is passed to
@@ -45,10 +47,43 @@ func (f RoundTripperFunc) RoundTrip(req *http.Request, ctx *ProxyCtx) (*http.Res
 }
 
 func (ctx *ProxyCtx) RoundTrip(req *http.Request) (*http.Response, error) {
+	var resp *http.Response
+	var err error
 	if ctx.RoundTripper != nil {
-		return ctx.RoundTripper.RoundTrip(req, ctx)
+		resp, err = ctx.RoundTripper.RoundTrip(req, ctx)
+	} else {
+		resp, err = ctx.Proxy.Tr.RoundTrip(req)
 	}
-	return ctx.Proxy.Tr.RoundTrip(req)
+	// Both response paths close the body more than once: handleHttp pairs
+	// a deferred Close with an explicit Close after io.Copy, and the MITM
+	// path pairs a deferred Close with Response.Write (which consumes the
+	// body). Standard net/http bodies tolerate double Close, but bodies
+	// from custom RoundTrippers may not — make Close idempotent at the
+	// single point every response enters the proxy.
+	//
+	// http.NoBody stays unwrapped so identity checks against it keep
+	// working (e.g. the MITM chunked-encoding decision), and 101 bodies
+	// stay unwrapped because WebSocket proxying type-asserts them to
+	// io.ReadWriter.
+	if resp != nil && resp.Body != nil && resp.Body != http.NoBody &&
+		resp.StatusCode != http.StatusSwitchingProtocols {
+		resp.Body = &onceCloseBody{ReadCloser: resp.Body}
+	}
+	return resp, err
+}
+
+// onceCloseBody is a response body whose Close is idempotent: the first
+// call closes the underlying body and records its error; later calls
+// return the same error without closing again.
+type onceCloseBody struct {
+	io.ReadCloser
+	once sync.Once
+	err  error
+}
+
+func (b *onceCloseBody) Close() error {
+	b.once.Do(func() { b.err = b.ReadCloser.Close() })
+	return b.err
 }
 
 func (ctx *ProxyCtx) printf(msg string, argv ...any) {

--- a/https.go
+++ b/https.go
@@ -378,6 +378,11 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 					origBody := resp.Body
 					resp = proxy.filterResponse(resp, ctx)
 					bodyModified := resp.Body != origBody
+					if bodyModified {
+						// The response filter replaced the body; nothing
+						// downstream closes the original.
+						defer origBody.Close()
+					}
 					defer resp.Body.Close()
 					if resp.Body != http.NoBody && (bodyModified ||
 						(resp.ContentLength <= 0 && resp.Header.Get("Content-Length") == "")) {

--- a/https.go
+++ b/https.go
@@ -264,6 +264,13 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 					return
 				}
 
+				// Need to explicitly send 100 continue for clients that will wait indefinitely for confirmation.
+				if req.Header.Get("Expect") == "100-continue" {
+					io.WriteString(rawClientTls, "HTTP/1.1 100 Continue\r\n\r\n")
+					// Strip the header before forwarding to upstream.
+					req.Header.Del("Expect")
+				}
+
 				// since we're converting the request, need to carry over the
 				// original connecting IP as well
 				req.RemoteAddr = r.RemoteAddr

--- a/https.go
+++ b/https.go
@@ -266,7 +266,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 
 				// Need to explicitly send 100 continue for clients that will wait indefinitely for confirmation.
 				if req.Header.Get("Expect") == "100-continue" {
-					io.WriteString(rawClientTls, "HTTP/1.1 100 Continue\r\n\r\n")
+					_, _ = io.WriteString(client, "HTTP/1.1 100 Continue\r\n\r\n")
 					// Strip the header before forwarding to upstream.
 					req.Header.Del("Expect")
 				}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -968,22 +968,25 @@ func TestHttpsMitmURLRewrite(t *testing.T) {
 func TestSimpleHttpRequest(t *testing.T) {
 	proxy := goproxy.NewProxyHttpServer()
 
-	var server *http.Server
+	// Bind an ephemeral port: a fixed port silently collides with other
+	// listeners (macOS AirPlay squats on :5000) and the client then talks
+	// to the wrong server.
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal("Cannot listen", err)
+	}
+	server := &http.Server{
+		Handler:           proxy,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
 	go func() {
-		t.Log("serving end proxy server at localhost:5000")
-		server = &http.Server{
-			Addr:              "localhost:5000",
-			Handler:           proxy,
-			ReadHeaderTimeout: 10 * time.Second,
-		}
-		err := server.ListenAndServe()
-		if err == nil {
+		t.Logf("serving end proxy server at %s", listener.Addr())
+		if err := server.Serve(listener); err == nil {
 			t.Error("Error shutdown should always return error", err)
 		}
 	}()
 
-	time.Sleep(1 * time.Second)
-	u, _ := url.Parse("http://localhost:5000")
+	u, _ := url.Parse("http://" + listener.Addr().String())
 	tr := &http.Transport{
 		Proxy: http.ProxyURL(u),
 		// Disable HTTP/2.


### PR DESCRIPTION
Opened by mistake — please disregard.