### PR TITLE
fix(mitm): never frame bodiless responses as chunked

### DIFF
--- a/https.go
+++ b/https.go
@@ -520,7 +520,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 					resp = proxy.filterResponse(resp, ctx)
 					bodyModified := resp.Body != origBody
 					defer resp.Body.Close()
-					if resp.Body != http.NoBody && (bodyModified ||
+					if responseBodyAllowed(req, resp) && resp.Body != http.NoBody && (bodyModified ||
 						(resp.ContentLength <= 0 && resp.Header.Get("Content-Length") == "")) {
 						// Return chunked encoded response when we don't know the length of the resp, if the body
 						// has been modified by the response handler or if there is no content length in the response.

--- a/https.go
+++ b/https.go
@@ -520,7 +520,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 					resp = proxy.filterResponse(resp, ctx)
 					bodyModified := resp.Body != origBody
 					defer resp.Body.Close()
-					if responseBodyAllowed(req, resp) && resp.Body != http.NoBody && (bodyModified ||
+					if responseBodyAllowed(ctx.Req, resp) && resp.Body != http.NoBody && (bodyModified ||
 						(resp.ContentLength <= 0 && resp.Header.Get("Content-Length") == "")) {
 						// Return chunked encoded response when we don't know the length of the resp, if the body
 						// has been modified by the response handler or if there is no content length in the response.

--- a/https_bodiless_test.go
+++ b/https_bodiless_test.go
@@ -1,0 +1,107 @@
+package goproxy_test
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/elazarl/goproxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A bodiless response (204, 304, HEAD) must not be framed as chunked: clients
+// stop at the header terminator, leaving the framing bytes to corrupt the next
+// response on a kept-alive connection.
+//
+// Both upstream protocols matter: an empty HTTP/2 body is not http.NoBody, so
+// an HTTP/1-only test proves nothing about the HTTP/2 path.
+func TestMitmBodilessResponseIsNotChunked(t *testing.T) {
+	cases := []struct {
+		name   string
+		method string
+		status int
+	}{
+		{name: "no content", method: http.MethodGet, status: http.StatusNoContent},
+		{name: "not modified", method: http.MethodGet, status: http.StatusNotModified},
+		{name: "head", method: http.MethodHead, status: http.StatusOK},
+	}
+
+	for _, upstreamHTTP2 := range []bool{false, true} {
+		for _, tc := range cases {
+			name := tc.name
+			if upstreamHTTP2 {
+				name += " over http2 upstream"
+			} else {
+				name += " over http1 upstream"
+			}
+
+			t.Run(name, func(t *testing.T) {
+				wantProtoMajor := 1
+				if upstreamHTTP2 {
+					wantProtoMajor = 2
+				}
+				handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// Without this the matrix silently collapses to six HTTP/1
+					// cases if ALPN negotiation ever stops working.
+					assert.Equal(t, wantProtoMajor, r.ProtoMajor)
+					w.WriteHeader(tc.status)
+				})
+
+				var upstream *httptest.Server
+				if upstreamHTTP2 {
+					upstream = httptest.NewUnstartedServer(handler)
+					upstream.EnableHTTP2 = true
+					upstream.StartTLS()
+				} else {
+					upstream = httptest.NewTLSServer(handler)
+				}
+				defer upstream.Close()
+
+				proxy := goproxy.NewProxyHttpServer()
+				proxy.Tr = &http.Transport{
+					ForceAttemptHTTP2: upstreamHTTP2,
+					TLSClientConfig: &tls.Config{
+						InsecureSkipVerify: true,
+					},
+				}
+				if upstreamHTTP2 {
+					proxy.Tr.TLSClientConfig.NextProtos = []string{"h2"}
+				}
+				proxy.OnRequest().HandleConnect(goproxy.AlwaysMitm)
+
+				proxySrv := httptest.NewServer(proxy)
+				defer proxySrv.Close()
+				proxyURL, err := url.Parse(proxySrv.URL)
+				require.NoError(t, err)
+
+				client := &http.Client{Transport: &http.Transport{
+					Proxy:           http.ProxyURL(proxyURL),
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				}}
+				defer client.CloseIdleConnections()
+
+				do := func() *http.Response {
+					req, err := http.NewRequestWithContext(context.Background(), tc.method, upstream.URL, http.NoBody)
+					require.NoError(t, err)
+					resp, err := client.Do(req)
+					require.NoError(t, err)
+					t.Cleanup(func() { _ = resp.Body.Close() })
+					return resp
+				}
+
+				resp := do()
+				require.Equal(t, tc.status, resp.StatusCode)
+				assert.Empty(t, resp.TransferEncoding,
+					"a response without a message body must not be framed as chunked")
+
+				// Reuse proves no stray framing bytes were left behind.
+				second := do()
+				assert.Equal(t, tc.status, second.StatusCode)
+			})
+		}
+	}
+}

--- a/https_bodiless_test.go
+++ b/https_bodiless_test.go
@@ -3,9 +3,11 @@ package goproxy_test
 import (
 	"context"
 	"crypto/tls"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/elazarl/goproxy"
@@ -21,13 +23,16 @@ import (
 // an HTTP/1-only test proves nothing about the HTTP/2 path.
 func TestMitmBodilessResponseIsNotChunked(t *testing.T) {
 	cases := []struct {
-		name   string
-		method string
-		status int
+		name        string
+		method      string
+		status      int
+		replaceBody bool
 	}{
 		{name: "no content", method: http.MethodGet, status: http.StatusNoContent},
 		{name: "not modified", method: http.MethodGet, status: http.StatusNotModified},
 		{name: "head", method: http.MethodHead, status: http.StatusOK},
+		{name: "no content with replaced body", method: http.MethodGet, status: http.StatusNoContent, replaceBody: true},
+		{name: "not modified with replaced body", method: http.MethodGet, status: http.StatusNotModified, replaceBody: true},
 	}
 
 	for _, upstreamHTTP2 := range []bool{false, true} {
@@ -72,6 +77,12 @@ func TestMitmBodilessResponseIsNotChunked(t *testing.T) {
 					proxy.Tr.TLSClientConfig.NextProtos = []string{"h2"}
 				}
 				proxy.OnRequest().HandleConnect(goproxy.AlwaysMitm)
+				if tc.replaceBody {
+					proxy.OnResponse().DoFunc(func(resp *http.Response, _ *goproxy.ProxyCtx) *http.Response {
+						resp.Body = io.NopCloser(strings.NewReader(""))
+						return resp
+					})
+				}
 
 				proxySrv := httptest.NewServer(proxy)
 				defer proxySrv.Close()
@@ -98,10 +109,43 @@ func TestMitmBodilessResponseIsNotChunked(t *testing.T) {
 				assert.Empty(t, resp.TransferEncoding,
 					"a response without a message body must not be framed as chunked")
 
-				// Reuse proves no stray framing bytes were left behind.
+				// Exercise a subsequent request on the client's persistent transport.
 				second := do()
 				assert.Equal(t, tc.status, second.StatusCode)
 			})
 		}
 	}
+}
+
+func TestMitmBodilessDirectResponseIsNotChunked(t *testing.T) {
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("direct response unexpectedly reached the upstream server")
+	}))
+	defer upstream.Close()
+
+	proxy := goproxy.NewProxyHttpServer()
+	proxy.OnRequest().HandleConnect(goproxy.AlwaysMitm)
+	proxy.OnRequest().DoFunc(func(req *http.Request, _ *goproxy.ProxyCtx) (*http.Request, *http.Response) {
+		return nil, goproxy.NewResponse(req, goproxy.ContentTypeText, http.StatusOK, "")
+	})
+
+	proxySrv := httptest.NewServer(proxy)
+	defer proxySrv.Close()
+	proxyURL, err := url.Parse(proxySrv.URL)
+	require.NoError(t, err)
+
+	client := &http.Client{Transport: &http.Transport{
+		Proxy:           http.ProxyURL(proxyURL),
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+	defer client.CloseIdleConnections()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodHead, upstream.URL, http.NoBody)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Empty(t, resp.TransferEncoding,
+		"a direct response to HEAD must not be framed as chunked")
 }

--- a/responses.go
+++ b/responses.go
@@ -42,3 +42,25 @@ const (
 func TextResponse(r *http.Request, text string) *http.Response {
 	return NewResponse(r, ContentTypeText, http.StatusAccepted, text)
 }
+
+// responseBodyAllowed reports whether a response may carry a message body.
+// RFC 9112 6.3: a response to HEAD, or with a 1xx, 204, or 304 status, ends at
+// the first empty line "regardless of the header fields present", so framing one
+// leaves those bytes to be misread as the next response.
+//
+// Keyed on status and method, not on the body value: an empty HTTP/1 body is
+// http.NoBody, but the HTTP/2 transport uses its own unexported value, so a
+// bodiless HTTP/2 response is not http.NoBody.
+func responseBodyAllowed(req *http.Request, resp *http.Response) bool {
+	if req != nil && req.Method == http.MethodHead {
+		return false
+	}
+	switch {
+	case resp.StatusCode >= 100 && resp.StatusCode <= 199:
+		return false
+	case resp.StatusCode == http.StatusNoContent, resp.StatusCode == http.StatusNotModified:
+		return false
+	default:
+		return true
+	}
+}


### PR DESCRIPTION
Avoid adding chunked transfer encoding to MITM responses that cannot contain a message body.

The existing check relies on `resp.Body == http.NoBody`. Empty HTTP/2 responses use a different body implementation,
causing HEAD, 204, and 304 responses to be framed as chunked when they are written back to the HTTP/1.1 client.