### PR TITLE
Echo client HTTP version in CONNECT tunnel reply (#802)

### DIFF
--- a/connect_reply_internal_test.go
+++ b/connect_reply_internal_test.go
@@ -1,0 +1,30 @@
+package goproxy
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestConnectResponseLineEchoesVersion verifies that CONNECT tunnel replies
+// echo the client's HTTP version instead of a hardcoded HTTP/1.0 (issue #802).
+func TestConnectResponseLineEchoesVersion(t *testing.T) {
+	cases := []struct {
+		name         string
+		major, minor int
+		text         string
+		want         string
+	}{
+		{"http1.1 established", 1, 1, "Connection established", "HTTP/1.1 200 Connection established\r\n\r\n"},
+		{"http1.0 established", 1, 0, "Connection established", "HTTP/1.0 200 Connection established\r\n\r\n"},
+		{"http1.1 ok", 1, 1, "OK", "HTTP/1.1 200 OK\r\n\r\n"},
+		{"unset falls back to 1.1", 0, 0, "OK", "HTTP/1.1 200 OK\r\n\r\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := &http.Request{ProtoMajor: c.major, ProtoMinor: c.minor}
+			if got := connectResponseLine(r, http.StatusOK, c.text); got != c.want {
+				t.Errorf("connectResponseLine(%d.%d) = %q, want %q", c.major, c.minor, got, c.want)
+			}
+		})
+	}
+}

--- a/https.go
+++ b/https.go
@@ -185,6 +185,19 @@ type halfClosable interface {
 
 var _ halfClosable = (*net.TCPConn)(nil)
 
+// connectResponseLine builds a CONNECT tunnel status line that echoes the
+// requesting client's HTTP version. These replies were previously hardcoded as
+// HTTP/1.0, so an HTTP/1.1 CONNECT received an HTTP/1.0 status line on an
+// otherwise HTTP/1.1 connection (issue #802). Falls back to HTTP/1.1 when the
+// request version is unset.
+func connectResponseLine(r *http.Request, code int, text string) string {
+	major, minor := r.ProtoMajor, r.ProtoMinor
+	if major == 0 {
+		major, minor = 1, 1
+	}
+	return fmt.Sprintf("HTTP/%d.%d %d %s\r\n\r\n", major, minor, code, text)
+}
+
 func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request) {
 	ctx := &ProxyCtx{Req: r, Session: atomic.AddInt64(&proxy.sess, 1), Proxy: proxy, certStore: proxy.CertStore}
 
@@ -325,7 +338,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 			}()
 			wg.Wait()
 		} else {
-			_, _ = proxyClient.Write([]byte("HTTP/1.0 200 Connection established\r\n\r\n"))
+			_, _ = proxyClient.Write([]byte(connectResponseLine(r, http.StatusOK, "Connection established")))
 
 			targetTCP, targetOK := targetSiteCon.(halfClosable)
 			proxyClientTCP, clientOK := proxyClient.(halfClosable)
@@ -384,7 +397,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 				f.Flush()
 			}
 		} else {
-			_, _ = proxyClient.Write([]byte("HTTP/1.0 200 OK\r\n\r\n"))
+			_, _ = proxyClient.Write([]byte(connectResponseLine(r, http.StatusOK, "OK")))
 		}
 		ctx.Logf("Received CONNECT request, mitm proxying it")
 		// For HTTP/1.x (after Hijack), the MITM loop runs in a goroutine so the HTTP/1.x


### PR DESCRIPTION
The two CONNECT success replies in https.go were hardcoded as HTTP/1.0, so an HTTP/1.1 client that sent 'CONNECT host:443 HTTP/1.1' received an HTTP/1.0 status line on an otherwise HTTP/1.1 connection (visible via 'curl -v --proxy ...'). The 407 reply on the same path already uses HTTP/1.1, so the 1.0 replies were also internally inconsistent.

Add connectResponseLine, which builds the status line from the request's ProtoMajor/ProtoMinor (falling back to HTTP/1.1 when unset), and use it at both CONNECT reply sites. Add a unit test covering 1.1, 1.0, and the fallback.