### PR TITLE
Forward buffered client bytes when starting MITM WebSocket relay

### DIFF
--- a/https.go
+++ b/https.go
@@ -589,7 +589,15 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 							ctx.Warnf("Cannot flush response header from mitm'd client: %v", err)
 							return false
 						}
-						proxy.proxyWebsocket(ctx, wsConn, client)
+						// The client can send its first WebSocket frame in the same write as the
+						// upgrade request, so those bytes are already in the request parser buffer.
+						// Relay them before the raw connection, or they never reach the origin.
+						br := clientReader.Reader()
+						buffered, _ := br.Peek(br.Buffered())
+						proxy.proxyWebsocket(ctx, wsConn, struct {
+							io.Reader
+							io.Writer
+						}{io.MultiReader(bytes.NewReader(buffered), client), client})
 						return false
 					}
 

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -1,11 +1,16 @@
 package goproxy_test
 
 import (
+	"bufio"
 	"context"
 	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -83,4 +88,120 @@ func TestWebSocketMitm(t *testing.T) {
 
 	assert.Equal(t, websocket.MessageText, mt)
 	assert.Equal(t, "ECHO: Hello WebSocket", string(response))
+}
+
+// maskedTextFrame builds a client WebSocket text frame. Client frames must be
+// masked, so we mask the payload with a fixed key.
+func maskedTextFrame(payload string) []byte {
+	mask := []byte{0x12, 0x34, 0x56, 0x78}
+	frame := []byte{0x81, byte(0x80 | len(payload))}
+	frame = append(frame, mask...)
+	for i := 0; i < len(payload); i++ {
+		frame = append(frame, payload[i]^mask[i%len(mask)])
+	}
+	return frame
+}
+
+// readHTTPHead reads one HTTP head one byte at a time, so that no byte after
+// the head is consumed into a buffer that the caller then drops.
+func readHTTPHead(t *testing.T, r io.Reader) string {
+	t.Helper()
+
+	var head []byte
+	buf := make([]byte, 1)
+	for !strings.HasSuffix(string(head), "\r\n\r\n") {
+		_, err := io.ReadFull(r, buf)
+		require.NoError(t, err)
+		head = append(head, buf[0])
+	}
+	return string(head)
+}
+
+func TestWebSocketMitmEarlyClientFrame(t *testing.T) {
+	// Start a WebSocket echo server
+	backend := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+		})
+		if err != nil {
+			return
+		}
+		defer func() {
+			_ = c.Close(websocket.StatusNormalClosure, "")
+		}()
+
+		ctx := r.Context()
+		for {
+			mt, message, err := c.Read(ctx)
+			if err != nil {
+				break
+			}
+			err = c.Write(ctx, mt, append([]byte("ECHO: "), message...))
+			if err != nil {
+				break
+			}
+		}
+	}))
+	backend.StartTLS()
+	defer backend.Close()
+
+	// Start goproxy
+	proxy := goproxy.NewProxyHttpServer()
+	proxy.Tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	proxy.OnRequest().HandleConnect(goproxy.AlwaysMitm)
+
+	proxyServer := httptest.NewServer(proxy)
+	defer proxyServer.Close()
+
+	backendURL, err := url.Parse(backend.URL)
+	require.NoError(t, err)
+	proxyURL, err := url.Parse(proxyServer.URL)
+	require.NoError(t, err)
+
+	// A raw client is required here: the bug only shows up when the first
+	// WebSocket frame is sent in the same write as the upgrade request.
+	var dialer net.Dialer
+	raw, err := dialer.DialContext(context.Background(), "tcp", proxyURL.Host)
+	require.NoError(t, err)
+	defer func() {
+		_ = raw.Close()
+	}()
+	require.NoError(t, raw.SetDeadline(time.Now().Add(5*time.Second)))
+
+	_, err = fmt.Fprintf(raw, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n\r\n", backendURL.Host, backendURL.Host)
+	require.NoError(t, err)
+	require.Contains(t, readHTTPHead(t, raw), " 200 ")
+
+	conn := tls.Client(raw, &tls.Config{
+		InsecureSkipVerify: true,
+		ServerName:         backendURL.Hostname(),
+	})
+	require.NoError(t, conn.HandshakeContext(context.Background()))
+
+	upgrade := "GET / HTTP/1.1\r\n" +
+		"Host: " + backendURL.Host + "\r\n" +
+		"Upgrade: websocket\r\n" +
+		"Connection: Upgrade\r\n" +
+		"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+		"Sec-WebSocket-Version: 13\r\n" +
+		"\r\n"
+	_, err = conn.Write(append([]byte(upgrade), maskedTextFrame("Hello")...))
+	require.NoError(t, err)
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+
+	// Server to client frames are not masked
+	header := make([]byte, 2)
+	_, err = io.ReadFull(br, header)
+	require.NoError(t, err)
+	assert.Equal(t, byte(0x81), header[0])
+
+	payload := make([]byte, int(header[1]&0x7f))
+	_, err = io.ReadFull(br, payload)
+	require.NoError(t, err)
+
+	assert.Equal(t, "ECHO: Hello", string(payload))
 }


### PR DESCRIPTION
Fixes #801

## Problem
In the HTTPS MITM path, the client request is parsed with a buffered reader. If the client sends its first WebSocket frame in the same write as the upgrade request, that frame stays in the buffer. After the 101, the relay reads from the raw connection, so the frame never reaches the origin. The client waits forever.

## Solution
When starting the relay, read the bytes still in the parser buffer first, then continue from the raw connection. Writes still go to the raw connection. One call site changed in `https.go`.

## Proof
New test `TestWebSocketMitmEarlyClientFrame`. A raw TLS client sends CONNECT, then the upgrade request and one masked frame in one write, then reads the echo.

Without the fix:
```
--- FAIL: TestWebSocketMitmEarlyClientFrame (5.01s)
    read tcp 127.0.0.1:54199->127.0.0.1:54198: i/o timeout
```
With the fix: passes, also under `-race` with `-count=3`. `golangci-lint run` reports 0 issues.

## Follow-on Items
- The non-MITM plain HTTP WebSocket path (`http.go`, `hijackConnection`) has the same shape: it drops the `bufio.ReadWriter` from `Hijack()` and relays from the raw conn. Not touched here to keep this change small.